### PR TITLE
Update nrrd.py

### DIFF
--- a/nrrd.py
+++ b/nrrd.py
@@ -156,6 +156,7 @@ _NRRD_REQUIRED_FIELDS = ['dimension', 'type', 'encoding', 'sizes']
 _NRRD_FIELD_ORDER = [
     'type',
     'dimension',
+    'space dimension',
     'space',
     'sizes',
     'space directions',
@@ -179,7 +180,6 @@ _NRRD_FIELD_ORDER = [
     'centerings',
     'labels',
     'units',
-    'space dimension',
     'space units',
     'space origin',
     'measurement frame']


### PR DESCRIPTION
Fixes problem opening in ImageJ/Fiji with 'space dimension' not being provided before 'space' and defaulting to 0 resulting in miss-match.
