### PR TITLE
fixed keyvaluepairs in writing files

### DIFF
--- a/nrrd.py
+++ b/nrrd.py
@@ -464,7 +464,7 @@ def write(filename, data, options={}, separate_header=False):
                            _NRRD_FIELD_FORMATTERS[field](options[field]) +
                            '\n')
                 filehandle.write(outline)
-        for (k,v) in options.get('keyvaluepairs',{}):
+		for (k,v) in options.get('keyvaluepairs', {}).items():
             outline = k + ':=' + v + '\n'
             filehandle.write(outline)
 


### PR DESCRIPTION
ValueError: too many values to unpack
was thrown before, because for loop over dictionary only returns key as loop variable. Values would have to be extracted manually from dictionary using get().

Use of .items() allows iteration over keys and values
