### PR TITLE
Fix filehandle corruption by read_header

### DIFF
--- a/nrrd.py
+++ b/nrrd.py
@@ -389,6 +389,7 @@ def read(filename):
     """Read a nrrd file and return a tuple (data, header)."""
     with open(filename,'rb') as filehandle:
         header = read_header(filehandle)
+    with open(filename,'rb') as filehandle:
         data = read_data(header, filehandle, filename)
         return (data, header)
 


### PR DESCRIPTION
Quick fix for apparent filehandle corruption by read_header. Re-closes the file before call to read_data. #25 
