### PR TITLE
Fix warning in _format_optional_nrrdvector

### DIFF
--- a/nrrd.py
+++ b/nrrd.py
@@ -387,7 +387,7 @@ def _format_nrrdvector(vector):
     return '(' + ','.join([_to_reproducible_float(x) for x in vector]) + ')'
 
 def _format_optional_nrrdvector(vector):
-    if vector == 'none':
+    if vector is None:
         return 'none'
     else:
         return _format_nrrdvector(vector)


### PR DESCRIPTION
When using _format_optional_nrrdvector with a valid vector, the warning 
> FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison

will appear because the vector is being compared to a string. Compare to None type instead