### PR TITLE
Fix string decode in read_header

### DIFF
--- a/nrrd.py
+++ b/nrrd.py
@@ -320,13 +320,20 @@ def read_header(nrrdfile):
     header_size = 0
 
     it = iter(nrrdfile)
+    magic_line = next(it)
 
-    header_size += _validate_magic_line(next(it).decode('ascii', 'ignore'))
+    need_decode = False
+    if hasattr(magic_line, 'decode'):
+        need_decode = True
+        magic_line = magic_line.decode('ascii', 'ignore')
+
+    header_size += _validate_magic_line(magic_line)
 
     header = {u'keyvaluepairs': {}}
     for raw_line in it:
         header_size += len(raw_line)
-        raw_line = raw_line.decode('ascii', 'ignore')
+        if need_decode:
+            raw_line = raw_line.decode('ascii', 'ignore')
 
         # Trailing whitespace ignored per the NRRD spec
         line = raw_line.rstrip()

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -1,5 +1,5 @@
-import sys
 import os
+import sys
 import tempfile
 
 # Look on level up for nrrd.py
@@ -7,18 +7,17 @@ sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import nrrd
 import unittest
-from os.path import dirname, join, basename
 
-DATA_DIR_PATH  = os.path.dirname(__file__) 
+DATA_DIR_PATH = os.path.dirname(__file__)
 RAW_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30.nrrd')
 RAW_NHDR_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30.nhdr')
 RAW_DATA_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30.raw')
-GZ_NRRD_FILE_PATH  = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_gz.nrrd')
-BZ2_NRRD_FILE_PATH  = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_bz2.nrrd')
-GZ_LINESKIP_NRRD_FILE_PATH  = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_gz_lineskip.nrrd')
+GZ_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_gz.nrrd')
+BZ2_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_bz2.nrrd')
+GZ_LINESKIP_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_gz_lineskip.nrrd')
+
 
 class TestReadingFunctions(unittest.TestCase):
-
     def setUp(self):
         self.expected_header = {u'dimension': 3,
                                 u'encoding': 'raw',
@@ -39,6 +38,10 @@ class TestReadingFunctions(unittest.TestCase):
             header = nrrd.read_header(f)
         self.assertEqual(self.expected_header, header)
 
+    def test_read_header_only_filename(self):
+        header = nrrd.read_header(RAW_NRRD_FILE_PATH)
+        self.assertEqual(self.expected_header, header)
+
     def test_read_detached_header_only(self):
         header = None
         expected_header = self.expected_header
@@ -47,11 +50,26 @@ class TestReadingFunctions(unittest.TestCase):
             header = nrrd.read_header(f)
         self.assertEqual(self.expected_header, header)
 
+    def test_read_detached_header_only_filename(self):
+        expected_header = self.expected_header
+        expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
+        header = nrrd.read_header(RAW_NHDR_FILE_PATH)
+        self.assertEqual(self.expected_header, header)
+
     def test_read_header_and_data(self):
+        data = None
+        header = None
+        with open(RAW_DATA_FILE_PATH, 'rb') as f:
+            data, header = nrrd.read(f)
+        self.assertEqual(self.expected_header, header)
+        self.assertEqual(self.expected_data, data.tostring(order='F'))
+
+    def test_read_header_and_data_filename(self):
         data, header = nrrd.read(RAW_NRRD_FILE_PATH)
         self.assertEqual(self.expected_header, header)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
 
+    # TODO Add one more test for detached headers...
     def test_read_detached_header_and_data(self):
         expected_header = self.expected_header
         expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
@@ -91,7 +109,7 @@ class TestWritingFunctions(unittest.TestCase):
 
     def write_and_read_back_with_encoding(self, encoding):
         output_filename = os.path.join(self.temp_write_dir, "testfile_%s.nrrd" % encoding)
-        nrrd.write(output_filename, self.data_input, {u'encoding':encoding})
+        nrrd.write(output_filename, self.data_input, {u'encoding': encoding})
         # Read back the same file
         data, header = nrrd.read(output_filename)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
@@ -105,6 +123,7 @@ class TestWritingFunctions(unittest.TestCase):
 
     def test_write_bz2(self):
         self.write_and_read_back_with_encoding(u'bzip2')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -47,8 +47,8 @@ class TestReadingFunctions(unittest.TestCase):
         self.assertEqual(self.expected_header, header)
 
     def test_read_detached_header_only_filename(self):
-        self.assertRaisesRegex(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?', nrrd.read_header,
-                               RAW_NHDR_FILE_PATH)
+        with self.assertRaisesRegexp(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?'):
+            nrrd.read_header(RAW_NHDR_FILE_PATH)
 
     def test_read_header_and_data_filename(self):
         data, header = nrrd.read(RAW_NRRD_FILE_PATH)

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -38,10 +38,6 @@ class TestReadingFunctions(unittest.TestCase):
             header = nrrd.read_header(f)
         self.assertEqual(self.expected_header, header)
 
-    def test_read_header_only_filename(self):
-        header = nrrd.read_header(RAW_NRRD_FILE_PATH)
-        self.assertEqual(self.expected_header, header)
-
     def test_read_detached_header_only(self):
         header = None
         expected_header = self.expected_header
@@ -51,25 +47,14 @@ class TestReadingFunctions(unittest.TestCase):
         self.assertEqual(self.expected_header, header)
 
     def test_read_detached_header_only_filename(self):
-        expected_header = self.expected_header
-        expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
-        header = nrrd.read_header(RAW_NHDR_FILE_PATH)
-        self.assertEqual(self.expected_header, header)
-
-    def test_read_header_and_data(self):
-        data = None
-        header = None
-        with open(RAW_DATA_FILE_PATH, 'rb') as f:
-            data, header = nrrd.read(f)
-        self.assertEqual(self.expected_header, header)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        self.assertRaisesRegex(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?', nrrd.read_header,
+                               RAW_NHDR_FILE_PATH)
 
     def test_read_header_and_data_filename(self):
         data, header = nrrd.read(RAW_NRRD_FILE_PATH)
         self.assertEqual(self.expected_header, header)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
 
-    # TODO Add one more test for detached headers...
     def test_read_detached_header_and_data(self):
         expected_header = self.expected_header
         expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
@@ -98,6 +83,15 @@ class TestReadingFunctions(unittest.TestCase):
         data, header = nrrd.read(GZ_LINESKIP_NRRD_FILE_PATH)
         self.assertEqual(self.expected_header, header)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
+
+    def test_read_raw_header(self):
+        expected_header = {u'type': 'float', u'dimension': 3, u'keyvaluepairs': {}}
+        header = nrrd.read_header(("NRRD0005", "type: float", "dimension: 3"))
+        self.assertEqual(expected_header, header)
+
+        expected_header = {u'keyvaluepairs': {u'my extra info': u'my : colon-separated : values'}}
+        header = nrrd.read_header(("NRRD0005", "my extra info:=my : colon-separated : values"))
+        self.assertEqual(expected_header, header)
 
 
 class TestWritingFunctions(unittest.TestCase):


### PR DESCRIPTION
In `read_header`, each line of the nrrdfile was decoded to ASCII. The `decode` function is only defined for a byte string (A.K.A when you open with 'b' suffix). An error occurs if you input a string list, such as the example given in docstring of `read_header`:
```
    >>> read_header(("NRRD0005", "type: float", "dimension: 3"))
    {u'type': 'float', u'dimension': 3, u'keyvaluepairs': {}}
    >>> read_header(("NRRD0005", "my extra info:=my : colon-separated : values"))
    {u'keyvaluepairs': {u'my extra info': u'my : colon-separated : values'}}
```

The error is: `AttributeError: 'str' object has no attribute 'decode'`

This PR fixes by checking if the data given has a decode attribute and if so the object will be decoded. This is ideal because a bytes or bytesarray could be given, both of which can be decoded.

Resolves issue #27. In #27, the issue was that `read_header` was given a filename string instead of file handle. The error now becomes:

`nrrd.NrrdError: Missing magic "NRRD" word. Is this an NRRD file?`