### PR TITLE
Two deprecations

### DIFF
--- a/nrrd.py
+++ b/nrrd.py
@@ -264,7 +264,7 @@ def read_data(fields, filehandle, filename=None):
                 break
             decompressed_data += decompobj.decompress(chunk)
         # byteskip applies to the _decompressed_ byte stream
-        data = np.fromstring(decompressed_data[byteskip:], dtype)
+        data = np.frombuffer(decompressed_data[byteskip:], dtype)
 
     if datafilehandle:
         datafilehandle.close()

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -48,9 +48,9 @@ class TestReadingFunctions(unittest.TestCase):
 
     def test_read_detached_header_only_filename(self):
         try:
-            assertRaisesRegex = self.assertRaisesRegex
+            assertRaisesRegex = self.assertRaisesRegex  # Python 3
         except AttributeError:
-            assertRaisesRegex = self.assertRaisesRegexp
+            assertRaisesRegex = self.assertRaisesRegexp  # Python 2
         with assertRaisesRegex(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?'):
             nrrd.read_header(RAW_NHDR_FILE_PATH)
 

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -47,7 +47,11 @@ class TestReadingFunctions(unittest.TestCase):
         self.assertEqual(self.expected_header, header)
 
     def test_read_detached_header_only_filename(self):
-        with self.assertRaisesRegex(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?'):
+        try:
+            assertRaisesRegex = self.assertRaisesRegex
+        except AttributeError:
+            assertRaisesRegex = self.assertRaisesRegexp
+        with assertRaisesRegex(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?'):
             nrrd.read_header(RAW_NHDR_FILE_PATH)
 
     def test_read_header_and_data_filename(self):

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -47,7 +47,7 @@ class TestReadingFunctions(unittest.TestCase):
         self.assertEqual(self.expected_header, header)
 
     def test_read_detached_header_only_filename(self):
-        with self.assertRaisesRegexp(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?'):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?'):
             nrrd.read_header(RAW_NHDR_FILE_PATH)
 
     def test_read_header_and_data_filename(self):


### PR DESCRIPTION
Using pynrrd to load data gave me a deprecation warning:

/opt/updated-python3/lib/python3.5/site-packages/nrrd.py:267: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
  data = np.fromstring(decompressed_data[byteskip:], dtype)

After forking and running your tests, I stumbled upon a second deprecation warning (assertRaisesRegexp vs. assertRaisesRegex).

I updated both. Tests are still running.