### PR TITLE
Add public parse and format functions for unknown fields

### DIFF
--- a/nrrd.py
+++ b/nrrd.py
@@ -274,11 +274,79 @@ def parse_number_auto_dtype(x):
     return value
 
 
+def format_number(x):
+    """Format number to string
+
+    Function converts a number to string. For numbers of class :class:`float`, up to 17 digits will be used to print the entire floating point number. Any padding zeros will be removed at the end of the number.
+
+    .. note::
+            IEEE754-1985 standard says that 17 significant decimal digits are required to adequately represent a 64-bit floating point number. Not all fractional numbers can be exactly represented in floating point. An example is 0.1 which will be approximated as 0.10000000000000001.
+
+    Parameters
+    ----------
+    x : :class:`int` or :class:`float`
+        Number to convert to string
+
+    Returns
+    -------
+    vector : :class:`str`
+        String of number :obj:`x`
+    """
+
+    if isinstance(x, float):
+        # Helps prevent loss of precision as using str() in Python 2 only prints 12 digits of precision.
+        # However, IEEE754-1985 standard says that 17 significant decimal digits is required to adequately represent a
+        # floating point number.
+        # The g option is used rather than f because g precision uses significant digits while f is just the number of
+        # digits after the decimal. (NRRD C implementation uses g).
+        value = '{:.17g}'.format(x)
+    else:
+        value = str(x)
+
+    return value
+
+
 def format_vector(x):
+    """Format a 1D Numpy array into NRRD vector string
+
+    Function converts a 1D Numpy array into a string using NRRD vector format.
+    A NRRD vector is structured as follows:
+        * (<Number 1>, <Number 2>, <Number 3>, ... <Number N>)
+
+    Parameters
+    ----------
+    x : (N,) :class:`numpy.ndarray`
+        Vector to convert to NRRD vector string
+
+    Returns
+    -------
+    vector : :class:`str`
+        String containing NRRD vector
+    """
     return '(' + ','.join([format_number(y) for y in x]) + ')'
 
 
 def format_optional_vector(x):
+    """Format a 1D Numpy array into NRRD optional vector string
+
+    Function converts a 1D Numpy array or None object into a string using NRRD vector format. If the input :obj:`x` is
+    None, then :obj:`vector` will be 'none'
+
+    An optional NRRD vector is structured as one of the following:
+        * (<Number 1>, <Number 2>, <Number 3>, ... <Number N>) OR
+        * none
+
+    Parameters
+    ----------
+    x : (N,) :class:`numpy.ndarray` or :obj:`None`
+        Vector to convert to NRRD vector string
+
+    Returns
+    -------
+    vector : :class:`str`
+        String containing NRRD vector
+    """
+
     # If vector is None or all elements are NaN, then return none
     # Otherwise format the vector as normal
     if x is None or np.all(np.isnan(x)):
@@ -297,20 +365,6 @@ def format_optional_matrix(x):
 
 def format_number_list(x):
     return ' '.join([format_number(y) for y in x])
-
-
-def format_number(x):
-    if isinstance(x, float):
-        # Helps prevent loss of precision as using str() in Python 2 only prints 12 digits of precision.
-        # However, IEEE754-1985 standard says that 17 significant decimal digits is required to adequately represent a
-        # floating point number.
-        # The g option is used rather than f because g precision uses significant digits while f is just the number of
-        # digits after the decimal. (NRRD C implementation uses g).
-        value = '{:.17g}'.format(x)
-    else:
-        value = str(x)
-
-    return value
 
 
 _TYPEMAP_NRRD2NUMPY = {

--- a/nrrd.py
+++ b/nrrd.py
@@ -111,7 +111,7 @@ def parse_vector(input, dtype=None):
     # TODO Document this better
 
     if input[0] != '(' or input[-1] != ')':
-        raise NrrdError("Vector should be enclosed by parentheses.")
+        raise NrrdError('Vector should be enclosed by parentheses.')
 
     # Always convert to float and then truncate to integer if desired
     # The reason why is parsing a floating point string to int will fail (i.e. int('25.1') will fail)
@@ -127,7 +127,7 @@ def parse_vector(input, dtype=None):
     elif dtype == int:
         vector = vector.astype(int)
     elif dtype != float:
-        raise NrrdError("dtype should be None for automatic type detection, float or int")
+        raise NrrdError('dtype should be None for automatic type detection, float or int')
 
     return vector
 
@@ -155,7 +155,7 @@ def parse_matrix(input, dtype=None):
     elif dtype == int:
         matrix = matrix.astype(int)
     elif dtype != float:
-        raise NrrdError("dtype should be None for automatic type detection, float or int")
+        raise NrrdError('dtype should be None for automatic type detection, float or int')
 
     return matrix
 
@@ -174,7 +174,7 @@ def parse_optional_matrix(input):
     unique_sizes = np.unique(sizes)
 
     assert len(unique_sizes) == 1 or (len(unique_sizes) == 2 and unique_sizes.min() == 0), \
-        "Matrix should have same number of elements in each row"
+        'Matrix should have same number of elements in each row'
 
     # Create a vector row of NaN's that matches same size of remaining vector rows
     # Stack the vector rows together to create matrix
@@ -196,7 +196,7 @@ def parse_number_list(input, dtype=None):
     elif dtype == int:
         number_list = number_list.astype(int)
     elif dtype != float:
-        raise NrrdError("dtype should be None for automatic type detection, float or int")
+        raise NrrdError('dtype should be None for automatic type detection, float or int')
 
     return number_list
 

--- a/nrrd.py
+++ b/nrrd.py
@@ -109,8 +109,9 @@ _NUMPY2NRRD_ENDIAN_MAP = {
 def parse_vector(input, dtype=None):
     """Parse a vector from a nrrd header, return a list."""
     # TODO Document this better
-    assert input[0] == '(', "Vector should be enclosed by parentheses."
-    assert input[-1] == ')', "Vector should be enclosed by parentheses."
+
+    if input[0] != '(' or input[-1] != ')':
+        raise NrrdError("Vector should be enclosed by parentheses.")
 
     # Always convert to float and then truncate to integer if desired
     # The reason why is parsing a floating point string to int will fail (i.e. int('25.1') will fail)

--- a/nrrd.py
+++ b/nrrd.py
@@ -156,7 +156,8 @@ def parse_matrix(x, dtype=None):
 def parse_optional_matrix(x):
     """Parse optional NRRD matrix from string into Numpy array.
 
-    Function parses optional NRRD matrix from string into an 2D Numpy array. This function works the same as :meth:`parse_matrix` except if a row vector in the matrix is none, the resulting row in the returned matrix will be
+    Function parses optional NRRD matrix from string into an 2D Numpy array. This function works the same as
+    :meth:`parse_matrix` except if a row vector in the matrix is none, the resulting row in the returned matrix will be
     all NaNs.
 
     For example, the following matrix NRRD input
@@ -280,7 +281,9 @@ def format_number(x):
     Function converts a number to string. For numbers of class :class:`float`, up to 17 digits will be used to print the entire floating point number. Any padding zeros will be removed at the end of the number.
 
     .. note::
-            IEEE754-1985 standard says that 17 significant decimal digits are required to adequately represent a 64-bit floating point number. Not all fractional numbers can be exactly represented in floating point. An example is 0.1 which will be approximated as 0.10000000000000001.
+            IEEE754-1985 standard says that 17 significant decimal digits are required to adequately represent a
+            64-bit floating point number. Not all fractional numbers can be exactly represented in floating point. An
+            example is 0.1 which will be approximated as 0.10000000000000001.
 
     Parameters
     ----------
@@ -356,14 +359,73 @@ def format_optional_vector(x):
 
 
 def format_matrix(x):
+    """Format a 2D Numpy array into NRRD matrix string
+
+    Function converts a 2D Numpy array into a string using the NRRD matrix format.
+    A NRRD matrix is structured as follows:
+        * (<Number 1>, <Number 2>, <Number 3>, ... <Number N>) (<Number 1>, <Number 2>, <Number 3>, ... <Number N>)
+
+    Parameters
+    ----------
+    x : (M,N) :class:`numpy.ndarray`
+        Matrix to convert to NRRD vector string
+
+    Returns
+    -------
+    matrix : :class:`str`
+        String containing NRRD matrix
+    """
     return ' '.join([format_vector(y) for y in x])
 
 
 def format_optional_matrix(x):
+    """Format a 2D Numpy array into a NRRD optional matrix string
+
+    Function converts a 2D Numpy array into a string using the NRRD matrix format. For any rows of the matrix that
+    contain all NaNs for each element, the row will be replaced with a 'none' indicating the row has no vector.
+    A NRRD matrix is structured as follows:
+        * (<Number 1>, <Number 2>, <Number 3>, ... <Number N>) (<Number 1>, <Number 2>, <Number 3>, ... <Number N>)
+
+    For example, the following matrix NRRD input
+
+      x:
+      array([[ nan,  nan,  nan],
+       [  1.,   2.,   3.],
+       [  4.,   5.,   6.],
+       [  7.,   8.,   9.]])
+
+    will return
+
+    Parameters
+    ----------
+    x : (M,N) :class:`numpy.ndarray`
+        Matrix to convert to NRRD vector string
+
+    Returns
+    -------
+    matrix : :class:`str`
+        String containing NRRD matrix
+    """
     return ' '.join([format_optional_vector(y) for y in x])
 
 
 def format_number_list(x):
+    """Format a 1D Numpy array into NRRD number list.
+
+    Function converts a 1D Numpy array into a string using NRRD number list format.
+    A NRRD number list is structured as follows:
+        * <Number 1> <Number 2> <Number 3> ... <Number N>
+
+    Parameters
+    ----------
+    x : (N,) :class:`numpy.ndarray`
+        Vector to convert to NRRD number list string
+
+    Returns
+    -------
+    list : :class:`str`
+        String containing NRRD list
+    """
     return ' '.join([format_number(y) for y in x])
 
 

--- a/nrrd.py
+++ b/nrrd.py
@@ -143,7 +143,14 @@ def parse_matrix(input, dtype=None):
     """Parse a vector from a nrrd header, return a list."""
 
     # Split input by spaces, convert each row into a vector and stack them vertically to get a matrix
-    matrix = np.vstack([parse_vector(x, dtype=float) for x in input.split()])
+    matrix = [parse_vector(x, dtype=float) for x in input.split()]
+
+    # Get the size of each row vector and then remove duplicate sizes
+    # There should be exactly one value in the matrix because all row sizes need to be the same
+    if len(np.unique([len(x) for x in matrix])) != 1:
+        raise NrrdError('Matrix should have same number of elements in each row')
+
+    matrix = np.vstack(matrix)
 
     # If using automatic datatype detection, then start by converting to float and determining if the number is whole
     # Truncate to integer if dtype is int also
@@ -173,8 +180,8 @@ def parse_optional_matrix(input):
     # return a second one (0) if there are None vectors
     unique_sizes = np.unique(sizes)
 
-    assert len(unique_sizes) == 1 or (len(unique_sizes) == 2 and unique_sizes.min() == 0), \
-        'Matrix should have same number of elements in each row'
+    if len(unique_sizes) != 1 and (len(unique_sizes) != 2 or unique_sizes.min() != 0):
+        raise NrrdError('Matrix should have same number of elements in each row')
 
     # Create a vector row of NaN's that matches same size of remaining vector rows
     # Stack the vector rows together to create matrix

--- a/nrrd.py
+++ b/nrrd.py
@@ -145,7 +145,9 @@ def format_vector(x):
 
 
 def format_optional_vector(x):
-    if x is None:
+    # If vector is None or all elements are NaN, then return none
+    # Otherwise format the vector as normal
+    if x is None or np.all(np.isnan(x)):
         return 'none'
     else:
         return format_vector(x)

--- a/nrrd.py
+++ b/nrrd.py
@@ -165,10 +165,12 @@ def format_number_list(x):
 
 def format_number(x):
     if isinstance(x, float):
-        # This will help prevent loss of precision
-        # IEEE754-1985 standard says that 15 decimal digits is enough in all cases.
-        # Remove trailing zeros, and dot if at end
-        value = '{:.15f}'.format(x).rstrip('0').rstrip('.')
+        # Helps prevent loss of precision as using str() in Python 2 only prints 12 digits of precision.
+        # However, IEEE754-1985 standard says that 17 significant decimal digits is required to adequately represent a
+        # floating point number.
+        # The g option is used rather than f because g precision uses significant digits while f is just the number of
+        # digits after the decimal. (NRRD C implementation uses g).
+        value = '{:.17g}'.format(x)
     else:
         value = str(x)
 

--- a/nrrd.py
+++ b/nrrd.py
@@ -166,9 +166,9 @@ def format_number_list(x):
 def format_number(x):
     if isinstance(x, float):
         # This will help prevent loss of precision
-        # IEEE754-1985 standard says that 16 decimal digits is enough in all cases.
+        # IEEE754-1985 standard says that 15 decimal digits is enough in all cases.
         # Remove trailing zeros, and dot if at end
-        value = '{:.16f}'.format(x).rstrip('0').rstrip('.')
+        value = '{:.15f}'.format(x).rstrip('0').rstrip('.')
     else:
         value = str(x)
 

--- a/nrrd.py
+++ b/nrrd.py
@@ -154,6 +154,39 @@ def parse_matrix(x, dtype=None):
 
 
 def parse_optional_matrix(x):
+    """Parse optional NRRD matrix from string into Numpy array.
+
+    Function parses optional NRRD matrix from string into an 2D Numpy array. This function works the same as :meth:`parse_matrix` except if a row vector in the matrix is none, the resulting row in the returned matrix will be
+    all NaNs.
+
+    For example, the following matrix NRRD input
+
+      x: 'none (1,2,3) (4,5,6) (7,8,9)'
+
+    will return
+
+      matrix:
+      array([[ nan,  nan,  nan],
+       [  1.,   2.,   3.],
+       [  4.,   5.,   6.],
+       [  7.,   8.,   9.]])
+
+    Parameters
+    ----------
+    x : :class:`str`
+        String containing NRRD matrix to convert to Numpy array
+    dtype : data-type, optional
+        Datatype to use for the resulting Numpy array. Datatype can be float, int or None. If dtype is None, then it
+        will be automatically determined by checking any of the matrix elements for fractional numbers. If found, then
+        the matrix will be converted to float datatype, otherwise the datatype will be int. Valid datatypes are float
+        or int. Default is to automatically determine datatype.
+
+    Returns
+    -------
+    matrix : (M,N) :class:`numpy.ndarray`
+        Matrix that is parsed from the :obj:`x` string
+    """
+
     # Split input by spaces to get each row and convert into a vector. The row can be 'none', in which case it will
     # return None
     matrix = [parse_optional_vector(x, dtype=float) for x in x.split()]
@@ -178,6 +211,28 @@ def parse_optional_matrix(x):
 
 
 def parse_number_list(x, dtype=None):
+    """Parse NRRD number list from string into Numpy array.
+
+    Function parses NRRD number list from string into an 1D Numpy array.
+    A NRRD number list is structured as follows:
+        * <Number 1> <Number 2> <Number 3> ... <Number N>
+
+    Parameters
+    ----------
+    x : :class:`str`
+        String containing NRRD number list to convert to Numpy array
+    dtype : data-type, optional
+        Datatype to use for the resulting Numpy array. Datatype can be float, int or None. If dtype is None, then it
+        will be automatically determined by checking any of the list elements for fractional numbers. If found, then
+        the list will be converted to float datatype, otherwise the datatype will be int. Valid datatypes are float
+        or int. Default is to automatically determine datatype.
+
+    Returns
+    -------
+    vector : (N,) :class:`numpy.ndarray`
+        Vector that is parsed from the :obj:`x` string
+    """
+
     # Always convert to float and then perform truncation to integer if necessary
     number_list = np.array([float(x) for x in x.split()])
 
@@ -195,6 +250,22 @@ def parse_number_list(x, dtype=None):
 
 
 def parse_number_auto_dtype(x):
+    """Parse number from string with automatic type detection.
+
+    Function parses input string and converts to a number using automatic type detection. If the number contains any
+    fractional parts, then the vector will be converted to float, otherwise int.
+
+    Parameters
+    ----------
+    x : :class:`str`
+        String
+
+    Returns
+    -------
+    result : :class:`int` or :class:`float`
+        Number parsed from :obj:`x` string
+    """
+
     value = float(x)
 
     if value.is_integer():

--- a/nrrd.py
+++ b/nrrd.py
@@ -30,8 +30,27 @@ class NrrdError(Exception):
 
 
 def parse_vector(x, dtype=None):
-    """Parse a vector from a nrrd header, return a list."""
-    # TODO Document this better
+    """Parse NRRD vector from string into Numpy array.
+
+    Function parses NRRD vector from string into an 1D Numpy array.
+    A NRRD vector is structured as follows:
+        * (<Number 1>, <Number 2>, <Number 3>, ... <Number N>)
+
+    Parameters
+    ----------
+    x : :class:`str`
+        String containing NRRD vector to convert to Numpy array
+    dtype : data-type, optional
+        Datatype to use for the resulting Numpy array. Datatype can be float, int or None. If dtype is None, then it
+        will be automatically determined by checking any of the vector elements for fractional numbers. If found, then
+        the vector will be converted to float datatype, otherwise the datatype will be int. Valid datatypes are float
+        or int. Default is to automatically determine datatype.
+
+    Returns
+    -------
+    vector : (N,) :class:`numpy.ndarray`
+        Vector that is parsed from the :obj:`x` string
+    """
 
     if x[0] != '(' or x[-1] != ')':
         raise NrrdError('Vector should be enclosed by parentheses.')
@@ -56,6 +75,30 @@ def parse_vector(x, dtype=None):
 
 
 def parse_optional_vector(x, dtype=None):
+    """Parse optional NRRD vector from string into Numpy array.
+
+    Function parses optional NRRD vector from string into an 1D Numpy array. This function works the same as
+    :meth:`parse_vector` except if the :obj:`x` is 'none', the result will be None
+
+    Thus, an optional NRRD vector is structured as one of the following:
+        * (<Number 1>, <Number 2>, <Number 3>, ... <Number N>) OR
+        * none
+
+    Parameters
+    ----------
+    x : :class:`str`
+        String containing NRRD vector to convert to Numpy array
+    dtype : data-type, optional
+        Datatype to use for the resulting Numpy array. Datatype can be float, int or None. If dtype is None, then it
+        will be automatically determined by checking any of the vector elements for fractional numbers. If found, then
+        the vector will be converted to float datatype, otherwise the datatype will be int. Valid datatypes are float
+        or int. Default is to automatically determine datatype.
+
+    Returns
+    -------
+    vector : (N,) :class:`numpy.ndarray`
+        Vector that is parsed from the :obj:`x` string OR None if :obj:`x` is 'none'
+    """
     if x == 'none':
         return None
     else:
@@ -63,7 +106,27 @@ def parse_optional_vector(x, dtype=None):
 
 
 def parse_matrix(x, dtype=None):
-    """Parse a vector from a nrrd header, return a list."""
+    """Parse NRRD matrix from string into Numpy array.
+
+    Function parses NRRD matrix from string into an 2D Numpy array.
+    A NRRD matrix is structured as follows:
+        * (<Number 1>, <Number 2>, <Number 3>, ... <Number N>) (<Number 1>, <Number 2>, <Number 3>, ... <Number N>)
+
+    Parameters
+    ----------
+    x : :class:`str`
+        String containing NRRD matrix to convert to Numpy array
+    dtype : data-type, optional
+        Datatype to use for the resulting Numpy array. Datatype can be float, int or None. If dtype is None, then it
+        will be automatically determined by checking any of the matrix elements for fractional numbers. If found, then
+        the matrix will be converted to float datatype, otherwise the datatype will be int. Valid datatypes are float
+        or int. Default is to automatically determine datatype.
+
+    Returns
+    -------
+    matrix : (M,N) :class:`numpy.ndarray`
+        Matrix that is parsed from the :obj:`x` string
+    """
 
     # Split input by spaces, convert each row into a vector and stack them vertically to get a matrix
     matrix = [parse_vector(x, dtype=float) for x in x.split()]

--- a/nrrd.py
+++ b/nrrd.py
@@ -126,6 +126,8 @@ def parse_vector(input, dtype=None):
             vector = vector_trunc
     elif dtype == int:
         vector = vector.astype(int)
+    elif dtype != float:
+        raise NrrdError("dtype should be None for automatic type detection, float or int")
 
     return vector
 
@@ -152,6 +154,8 @@ def parse_matrix(input, dtype=None):
             matrix = matrix_trunc
     elif dtype == int:
         matrix = matrix.astype(int)
+    elif dtype != float:
+        raise NrrdError("dtype should be None for automatic type detection, float or int")
 
     return matrix
 
@@ -191,6 +195,8 @@ def parse_number_list(input, dtype=None):
             number_list = number_list_trunc
     elif dtype == int:
         number_list = number_list.astype(int)
+    elif dtype != float:
+        raise NrrdError("dtype should be None for automatic type detection, float or int")
 
     return number_list
 

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -167,6 +167,135 @@ class TestFieldParsing(unittest.TestCase):
         self.assertEqual(nrrd.parse_number_auto_dtype('25.125'), 25.125)
 
 
+class TestFieldFormatting(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_format_vector(self):
+        self.assertEqual(nrrd.format_vector([1, 2, 3]), '(1,2,3)')
+        self.assertEqual(nrrd.format_vector([1., 2., 3.]), '(1,2,3)')
+        self.assertEqual(nrrd.format_vector([1.2, 2., 3.2]), '(1.2,2,3.2)')
+
+        self.assertEqual(nrrd.format_vector(np.array([1, 2, 3])), '(1,2,3)')
+        self.assertEqual(nrrd.format_vector(np.array([1., 2., 3.])), '(1,2,3)')
+        self.assertEqual(nrrd.format_vector(np.array([1.2, 2., 3.2])), '(1.2,2,3.2)')
+
+    def test_format_optional_vector(self):
+        self.assertEqual(nrrd.format_optional_vector([1, 2, 3]), '(1,2,3)')
+        self.assertEqual(nrrd.format_optional_vector([1., 2., 3.]), '(1,2,3)')
+        self.assertEqual(nrrd.format_optional_vector([1.2, 2., 3.2]), '(1.2,2,3.2)')
+
+        self.assertEqual(nrrd.format_optional_vector(np.array([1, 2, 3])), '(1,2,3)')
+        self.assertEqual(nrrd.format_optional_vector(np.array([1., 2., 3.])), '(1,2,3)')
+        self.assertEqual(nrrd.format_optional_vector(np.array([1.2, 2., 3.2])), '(1.2,2,3.2)')
+
+        self.assertEqual(nrrd.format_optional_vector(None), 'none')
+
+    # def test_format_optional_vector(self):
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
+    #         nrrd.parse_optional_vector('100, 200, 300)')
+    #
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
+    #         nrrd.parse_optional_vector('(100, 200, 300')
+    #
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
+    #         nrrd.parse_optional_vector('100, 200, 300')
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300)'), [100, 200, 300])
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300)', dtype=float),
+    #                                     [100., 200., 300.])
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300)', dtype=int), [100, 200, 300])
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.50, 200, 300)'), [100.50, 200., 300.])
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200.50, 300)', dtype=float),
+    #                                     [100., 200.50, 300.])
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300.50)', dtype=int),
+    #                                     [100, 200, 300])
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32, 300.50)'),
+    #                                     [100.47655, 220.32, 300.50])
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32, 300.50)', dtype=float),
+    #                                     [100.47655, 220.32, 300.50])
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32, 300.50)', dtype=int),
+    #                                     [100, 220, 300])
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32)'),
+    #                                     [100.47655, 220.32])
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32)', dtype=float),
+    #                                     [100.47655, 220.32])
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32)', dtype=int), [100, 220])
+    #
+    #     self.assertEqual(nrrd.parse_optional_vector('none'), None)
+    #
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
+    #         nrrd.parse_optional_vector('(100.47655, 220.32)', dtype=np.uint8)
+    #
+    # def test_parse_matrix(self):
+    #     self.assert_equal_with_datatype(
+    #         nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
+    #         [[1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0], [0, 0, 4.7619115092114601]])
+    #
+    #     self.assert_equal_with_datatype(
+    #         nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)',
+    #                           dtype=float),
+    #         [[1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0], [0, 0, 4.7619115092114601]])
+    #
+    #     self.assert_equal_with_datatype(
+    #         nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)',
+    #                           dtype=int), [[1, 0, 0], [0, 1, 0], [0, 0, 4]])
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)'),
+    #                                     [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    #     self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=float),
+    #                                     [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+    #     self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=int),
+    #                                     [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+    #
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
+    #         nrrd.parse_matrix('(1,0,0,0) (0,1,0) (0,0,1)')
+    #
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
+    #         nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=np.uint8)
+    #
+    # def test_parse_optional_matrix(self):
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
+    #         '(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
+    #         [[1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0], [0, 0, 4.7619115092114601]])
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix('(1,0,0) (0,1,0) (0,0,1)'),
+    #                                     [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
+    #         'none (1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
+    #         [[np.NaN, np.NaN, np.NaN], [1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0],
+    #          [0, 0, 4.7619115092114601]])
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
+    #         '(1.4726600000000003,-0,0) none (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
+    #         [[1.4726600000000003, 0, 0], [np.NaN, np.NaN, np.NaN], [0, 1.4726600000000003, 0],
+    #          [0, 0, 4.7619115092114601]])
+    #
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
+    #         nrrd.parse_optional_matrix('(1,0,0,0) (0,1,0) (0,0,1)')
+    #
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
+    #         nrrd.parse_optional_matrix('none (1,0,0,0) (0,1,0) (0,0,1)')
+    #
+    # def test_parse_number_list(self):
+    #     self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4'), [1, 2, 3, 4])
+    #     self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4', dtype=float), [1., 2., 3., 4.])
+    #     self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4', dtype=int), [1, 2, 3, 4])
+    #
+    #     self.assert_equal_with_datatype(nrrd.parse_number_list('1'), [1])
+    #
+    #     with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
+    #         nrrd.parse_number_list('1 2 3 4', dtype=np.uint8)
+    #
+    # def test_parse_number_auto_dtype(self):
+    #     self.assertEqual(nrrd.parse_number_auto_dtype('25'), 25)
+    #     self.assertEqual(nrrd.parse_number_auto_dtype('25.125'), 25.125)
+
+
 class TestReadingFunctions(unittest.TestCase):
     def setUp(self):
         self.expected_header = {u'dimension': 3,

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -171,6 +171,20 @@ class TestFieldFormatting(unittest.TestCase):
     def setUp(self):
         pass
 
+    def test_format_number(self):
+        # Loop through 0 -> 10 in increments of 0.1 and test if the formatted number equals what str(number) returns.
+        for x in np.linspace(0.1, 10.0, 100):
+            self.assertEqual(nrrd.format_number(x), repr(x))
+
+        # A few example floating points and the resulting output numbers that should be seen
+        values = {
+            123412341234.123: '123412341234.123',
+            0.000000123123: '1.23123e-07'
+        }
+
+        for key, value in values.items():
+            self.assertEqual(nrrd.format_number(key), value)
+
     def test_format_vector(self):
         self.assertEqual(nrrd.format_vector([1, 2, 3]), '(1,2,3)')
         self.assertEqual(nrrd.format_vector([1., 2., 3.]), '(1,2,3)')
@@ -191,45 +205,11 @@ class TestFieldFormatting(unittest.TestCase):
 
         self.assertEqual(nrrd.format_optional_vector(None), 'none')
 
-    # def test_format_optional_vector(self):
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
-    #         nrrd.parse_optional_vector('100, 200, 300)')
-    #
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
-    #         nrrd.parse_optional_vector('(100, 200, 300')
-    #
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
-    #         nrrd.parse_optional_vector('100, 200, 300')
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300)'), [100, 200, 300])
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300)', dtype=float),
-    #                                     [100., 200., 300.])
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300)', dtype=int), [100, 200, 300])
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.50, 200, 300)'), [100.50, 200., 300.])
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200.50, 300)', dtype=float),
-    #                                     [100., 200.50, 300.])
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300.50)', dtype=int),
-    #                                     [100, 200, 300])
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32, 300.50)'),
-    #                                     [100.47655, 220.32, 300.50])
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32, 300.50)', dtype=float),
-    #                                     [100.47655, 220.32, 300.50])
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32, 300.50)', dtype=int),
-    #                                     [100, 220, 300])
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32)'),
-    #                                     [100.47655, 220.32])
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32)', dtype=float),
-    #                                     [100.47655, 220.32])
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100.47655, 220.32)', dtype=int), [100, 220])
-    #
-    #     self.assertEqual(nrrd.parse_optional_vector('none'), None)
-    #
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
-    #         nrrd.parse_optional_vector('(100.47655, 220.32)', dtype=np.uint8)
-    #
+    def test_format_matrix(self):
+        self.assertEqual(nrrd.format_matrix(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])), '(1,2,3) (4,5,6) (7,8,9)')
+        # self.assertEqual(nrrd.format_matrix(np.array([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]])), '(1,2,3) (4,5,6) (7,8,9)')
+        # self.assertEqual(nrrd.format_matrix(np.array([[1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]])), '(1,2.2,3.3) (4.4,5.5,6.6) (7.7,8.8,9.9)')
+
     # def test_parse_matrix(self):
     #     self.assert_equal_with_datatype(
     #         nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+import numpy as np
 
 # Look on level up for nrrd.py
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -17,6 +18,66 @@ BZ2_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_bz2.nrrd')
 GZ_LINESKIP_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_gz_lineskip.nrrd')
 
 
+# Fix issue with assertRaisesRegex only available in Python 3 while
+# assertRaisesRegexp is available in Python 2 (and deprecated in Python 3)
+if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
+    unittest.TestCase.assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegexp')
+
+
+class TestFieldParsing(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_parse_vector(self):
+        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+            nrrd.parse_vector('100, 200, 300)') # Should assert
+
+        # self.assertRaises()
+
+        # vector = nrrd.parse_vector('(100, 200, 300)')
+        # self.assertEqual(vector.dtype, float)
+
+        # nrrd.parse_vector('(100, 200, 300)', dtype=float)
+        # nrrd.parse_vector('(100, 200, 300)', dtype=int)
+        #
+        # nrrd.parse_vector('(100.50, 200, 300)')
+        # nrrd.parse_vector('(100, 200.50, 300)', dtype=float)
+        # nrrd.parse_vector('(100, 200, 300.50)', dtype=int)
+        #
+        # nrrd.parse_vector('(100.47655, 220.32, 300.50)')
+        # nrrd.parse_vector('(100.47655, 220.32, 300.50)', dtype=float)
+        # nrrd.parse_vector('(100.47655, 220.32, 300.50)', dtype=int)
+        #
+        # nrrd.parse_vector('(100.47655, 220.32)')
+        # nrrd.parse_vector('(100.47655, 220.32)', dtype=float)
+        # nrrd.parse_vector('(100.47655, 220.32)', dtype=int)
+
+
+
+        # Testing vector parsing
+        print(nrrd.parse_vector('(100, 200, 300)'))
+        # print(nrrd.parse_vector('(100, 200, 300.00001)'))
+        # print(nrrd.parse_vector('(100.5, 200.1, 300)'))
+        # print(nrrd.parse_vector('(100.20, 200, 300)'))
+        # print(nrrd.parse_vector('(100, 200.20, 300)'))
+        #
+        # print('')
+        # print(nrrd.parse_vector('(100, 200, 300)', dtype=float))
+        # print(nrrd.parse_vector('(100, 200, 300)', dtype=int))
+        # print(nrrd.parse_vector('(100, 200, 300.00001)', dtype=int))
+        # print(nrrd.parse_vector('(100.5, 200.1, 300)', dtype=int))
+
+        # Test parse_matrix function
+        # print(nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'))
+        # print(nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)', dtype=int))
+        # print(nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)', dtype=float))
+
+        # print(nrrd.parse_optional_matrix('none (1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'))
+
+        # print(nrrd.parse_number_list('25 0 30 100 24 34'))
+
+        # print(nrrd.parse_number_auto_dtype('25'))
+
 class TestReadingFunctions(unittest.TestCase):
     def setUp(self):
         self.expected_header = {u'dimension': 3,
@@ -24,10 +85,10 @@ class TestReadingFunctions(unittest.TestCase):
                                 u'endian': 'little',
                                 u'keyvaluepairs': {},
                                 u'kinds': ['domain', 'domain', 'domain'],
-                                u'sizes': [30, 30, 30],
+                                u'sizes': np.array([30, 30, 30]),
                                 u'space': 'left-posterior-superior',
-                                u'space directions': [['1', '0', '0'], ['0', '1', '0'], ['0', '0', '1']],
-                                u'space origin': ['0', '0', '0'],
+                                u'space directions': np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+                                u'space origin': np.array([0, 0, 0]),
                                 u'type': 'short'}
         with open(RAW_DATA_FILE_PATH, 'rb') as f:
             self.expected_data = f.read()
@@ -36,7 +97,7 @@ class TestReadingFunctions(unittest.TestCase):
         header = None
         with open(RAW_NRRD_FILE_PATH, 'rb') as f:
             header = nrrd.read_header(f)
-        self.assertEqual(self.expected_header, header)
+        np.testing.assert_equal(self.expected_header, header)
 
     def test_read_detached_header_only(self):
         header = None
@@ -44,40 +105,41 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
         with open(RAW_NHDR_FILE_PATH, 'rb') as f:
             header = nrrd.read_header(f)
-        self.assertEqual(self.expected_header, header)
+        np.testing.assert_equal(self.expected_header, header)
 
     def test_read_detached_header_only_filename(self):
-        try:
-            assertRaisesRegex = self.assertRaisesRegex  # Python 3
-        except AttributeError:
-            assertRaisesRegex = self.assertRaisesRegexp  # Python 2
-        with assertRaisesRegex(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?'):
+        # try:
+        #     assertRaisesRegex = self.assertRaisesRegex  # Python 3
+        # except AttributeError:
+        #     assertRaisesRegex = self.assertRaisesRegexp  # Python 2
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Missing magic "NRRD" word. Is this an NRRD file\?'):
             nrrd.read_header(RAW_NHDR_FILE_PATH)
 
     def test_read_header_and_data_filename(self):
         data, header = nrrd.read(RAW_NRRD_FILE_PATH)
-        self.assertEqual(self.expected_header, header)
+        np.testing.assert_equal(self.expected_header, header)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
 
     def test_read_detached_header_and_data(self):
         expected_header = self.expected_header
         expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
         data, header = nrrd.read(RAW_NHDR_FILE_PATH)
-        self.assertEqual(expected_header, header)
+
+        np.testing.assert_equal(expected_header, header)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
 
     def test_read_header_and_gz_compressed_data(self):
         expected_header = self.expected_header
         expected_header[u'encoding'] = 'gzip'
         data, header = nrrd.read(GZ_NRRD_FILE_PATH)
-        self.assertEqual(self.expected_header, header)
+        np.testing.assert_equal(self.expected_header, header)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
 
     def test_read_header_and_bz2_compressed_data(self):
         expected_header = self.expected_header
         expected_header[u'encoding'] = 'bzip2'
         data, header = nrrd.read(BZ2_NRRD_FILE_PATH)
-        self.assertEqual(self.expected_header, header)
+        np.testing.assert_equal(self.expected_header, header)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
 
     def test_read_header_and_gz_compressed_data_with_lineskip3(self):
@@ -85,7 +147,7 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header[u'encoding'] = 'gzip'
         expected_header[u'line skip'] = 3
         data, header = nrrd.read(GZ_LINESKIP_NRRD_FILE_PATH)
-        self.assertEqual(self.expected_header, header)
+        np.testing.assert_equal(self.expected_header, header)
         self.assertEqual(self.expected_data, data.tostring(order='F'))
 
     def test_read_raw_header(self):

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -245,30 +245,15 @@ class TestFieldFormatting(unittest.TestCase):
                          [1, 2, 3], [np.NaN, np.NaN, np.NaN], [4, 5, 6], [7, 8, 9]])),
                          '(1,2,3) none (4,5,6) (7,8,9)')
 
-    # def test_parse_optional_matrix(self):
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
-    #         '(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
-    #         [[1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0], [0, 0, 4.7619115092114601]])
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix('(1,0,0) (0,1,0) (0,0,1)'),
-    #                                     [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
-    #         'none (1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
-    #         [[np.NaN, np.NaN, np.NaN], [1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0],
-    #          [0, 0, 4.7619115092114601]])
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
-    #         '(1.4726600000000003,-0,0) none (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
-    #         [[1.4726600000000003, 0, 0], [np.NaN, np.NaN, np.NaN], [0, 1.4726600000000003, 0],
-    #          [0, 0, 4.7619115092114601]])
-    #
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
-    #         nrrd.parse_optional_matrix('(1,0,0,0) (0,1,0) (0,0,1)')
-    #
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
-    #         nrrd.parse_optional_matrix('none (1,0,0,0) (0,1,0) (0,0,1)')
-    #
+    def test_format_number_list(self):
+        self.assertEqual(nrrd.format_number_list([1, 2, 3]), '1 2 3')
+        self.assertEqual(nrrd.format_number_list([1., 2., 3.]), '1 2 3')
+        self.assertEqual(nrrd.format_number_list([1.2, 2., 3.2]), '1.2 2 3.2000000000000002')
+
+        self.assertEqual(nrrd.format_number_list(np.array([1, 2, 3])), '1 2 3')
+        self.assertEqual(nrrd.format_number_list(np.array([1., 2., 3.])), '1 2 3')
+        self.assertEqual(nrrd.format_number_list(np.array([1.2, 2., 3.2])), '1.2 2 3.2000000000000002')
+
     # def test_parse_number_list(self):
     #     self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4'), [1, 2, 3, 4])
     #     self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4', dtype=float), [1., 2., 3., 4.])

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -122,6 +122,9 @@ class TestFieldParsing(unittest.TestCase):
         self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=int),
                                         [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
+            nrrd.parse_matrix('(1,0,0,0) (0,1,0) (0,0,1)')
+
         with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
             nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=np.uint8)
 
@@ -142,6 +145,12 @@ class TestFieldParsing(unittest.TestCase):
             '(1.4726600000000003,-0,0) none (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
             [[1.4726600000000003, 0, 0], [np.NaN, np.NaN, np.NaN], [0, 1.4726600000000003, 0],
              [0, 0, 4.7619115092114601]])
+
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
+            nrrd.parse_optional_matrix('(1,0,0,0) (0,1,0) (0,0,1)')
+
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
+            nrrd.parse_optional_matrix('none (1,0,0,0) (0,1,0) (0,0,1)')
 
     def test_parse_number_list(self):
         self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4'), [1, 2, 3, 4])

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -217,7 +217,7 @@ class TestFieldFormatting(unittest.TestCase):
 
         self.assertEqual(nrrd.format_matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), '(1,2,3) (4,5,6) (7,8,9)')
         self.assertEqual(nrrd.format_matrix([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]), '(1,2,3) (4,5,6) '
-                                                                                                   '(7,8,9)')
+                                                                                         '(7,8,9)')
         self.assertEqual(nrrd.format_matrix([[1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]]),
                          '(1,2.2000000000000002,3.2999999999999998) (4.4000000000000004,5.5,6.5999999999999996) '
                          '(7.7000000000000002,8.8000000000000007,9.9000000000000004)')
@@ -239,11 +239,11 @@ class TestFieldFormatting(unittest.TestCase):
                          '(7.7000000000000002,8.8000000000000007,9.9000000000000004)')
 
         self.assertEqual(nrrd.format_optional_matrix(np.array([
-                         [np.NaN, np.NaN, np.NaN], [1, 2, 3], [4, 5, 6], [7, 8, 9]])),
-                         'none (1,2,3) (4,5,6) (7,8,9)')
+            [np.NaN, np.NaN, np.NaN], [1, 2, 3], [4, 5, 6], [7, 8, 9]])),
+            'none (1,2,3) (4,5,6) (7,8,9)')
         self.assertEqual(nrrd.format_optional_matrix(np.array([
-                         [1, 2, 3], [np.NaN, np.NaN, np.NaN], [4, 5, 6], [7, 8, 9]])),
-                         '(1,2,3) none (4,5,6) (7,8,9)')
+            [1, 2, 3], [np.NaN, np.NaN, np.NaN], [4, 5, 6], [7, 8, 9]])),
+            '(1,2,3) none (4,5,6) (7,8,9)')
 
     def test_format_number_list(self):
         self.assertEqual(nrrd.format_number_list([1, 2, 3]), '1 2 3')
@@ -253,20 +253,6 @@ class TestFieldFormatting(unittest.TestCase):
         self.assertEqual(nrrd.format_number_list(np.array([1, 2, 3])), '1 2 3')
         self.assertEqual(nrrd.format_number_list(np.array([1., 2., 3.])), '1 2 3')
         self.assertEqual(nrrd.format_number_list(np.array([1.2, 2., 3.2])), '1.2 2 3.2000000000000002')
-
-    # def test_parse_number_list(self):
-    #     self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4'), [1, 2, 3, 4])
-    #     self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4', dtype=float), [1., 2., 3., 4.])
-    #     self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4', dtype=int), [1, 2, 3, 4])
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_number_list('1'), [1])
-    #
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
-    #         nrrd.parse_number_list('1 2 3 4', dtype=np.uint8)
-    #
-    # def test_parse_number_auto_dtype(self):
-    #     self.assertEqual(nrrd.parse_number_auto_dtype('25'), 25)
-    #     self.assertEqual(nrrd.parse_number_auto_dtype('25.125'), 25.125)
 
 
 class TestReadingFunctions(unittest.TestCase):

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -24,38 +24,49 @@ if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
     unittest.TestCase.assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegexp')
 
 
+# class CustomTestCase(unittest.TestCase):
+#     def npAssertAlmostEqual(self, first, second, rtol=1e-06, atol=1e-08):
+#         np.testing.assert_allclose(first, second, rtol=rtol, atol=atol)
+
 class TestFieldParsing(unittest.TestCase):
     def setUp(self):
         pass
 
+    def assert_equal_with_datatype(self, desired, actual):
+        self.assertEqual(desired.dtype, type(actual[0]))
+        np.testing.assert_equal(desired, actual)
+
     def test_parse_vector(self):
         with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
-            nrrd.parse_vector('100, 200, 300)') # Should assert
+            nrrd.parse_vector('100, 200, 300)')
 
-        # self.assertRaises()
+        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+            nrrd.parse_vector('(100, 200, 300')
 
-        # vector = nrrd.parse_vector('(100, 200, 300)')
-        # self.assertEqual(vector.dtype, float)
+        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+            nrrd.parse_vector('100, 200, 300')
 
-        # nrrd.parse_vector('(100, 200, 300)', dtype=float)
-        # nrrd.parse_vector('(100, 200, 300)', dtype=int)
-        #
-        # nrrd.parse_vector('(100.50, 200, 300)')
-        # nrrd.parse_vector('(100, 200.50, 300)', dtype=float)
-        # nrrd.parse_vector('(100, 200, 300.50)', dtype=int)
-        #
-        # nrrd.parse_vector('(100.47655, 220.32, 300.50)')
-        # nrrd.parse_vector('(100.47655, 220.32, 300.50)', dtype=float)
-        # nrrd.parse_vector('(100.47655, 220.32, 300.50)', dtype=int)
-        #
-        # nrrd.parse_vector('(100.47655, 220.32)')
-        # nrrd.parse_vector('(100.47655, 220.32)', dtype=float)
-        # nrrd.parse_vector('(100.47655, 220.32)', dtype=int)
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100, 200, 300)'), [100, 200, 300])
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100, 200, 300)', dtype=float), [100., 200., 300.])
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100, 200, 300)', dtype=int), [100, 200, 300])
+
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100.50, 200, 300)'), [100.50, 200., 300.])
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100, 200.50, 300)', dtype=float), [100., 200.50, 300.])
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100, 200, 300.50)', dtype=int), [100, 200, 300])
+
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32, 300.50)'), [100.47655, 220.32, 300.50])
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32, 300.50)', dtype=float),
+                                        [100.47655, 220.32, 300.50])
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32, 300.50)', dtype=int), [100, 220, 300])
+
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32)'), [100.47655, 220.32])
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32)', dtype=float), [100.47655, 220.32])
+        self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32)', dtype=int), [100, 220])
 
 
 
         # Testing vector parsing
-        print(nrrd.parse_vector('(100, 200, 300)'))
+        # print(nrrd.parse_vector('(100, 200, 300)'))
         # print(nrrd.parse_vector('(100, 200, 300.00001)'))
         # print(nrrd.parse_vector('(100.5, 200.1, 300)'))
         # print(nrrd.parse_vector('(100.20, 200, 300)'))

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -33,13 +33,13 @@ class TestFieldParsing(unittest.TestCase):
         np.testing.assert_equal(desired, actual)
 
     def test_parse_vector(self):
-        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
             nrrd.parse_vector('100, 200, 300)')
 
-        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
             nrrd.parse_vector('(100, 200, 300')
 
-        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
             nrrd.parse_vector('100, 200, 300')
 
         self.assert_equal_with_datatype(nrrd.parse_vector('(100, 200, 300)'), [100, 200, 300])
@@ -59,17 +59,17 @@ class TestFieldParsing(unittest.TestCase):
         self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32)', dtype=float), [100.47655, 220.32])
         self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32)', dtype=int), [100, 220])
 
-        with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
             nrrd.parse_vector('(100.47655, 220.32)', dtype=np.uint8)
 
     def test_parse_optional_vector(self):
-        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
             nrrd.parse_optional_vector('100, 200, 300)')
 
-        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
             nrrd.parse_optional_vector('(100, 200, 300')
 
-        with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'Vector should be enclosed by parentheses.'):
             nrrd.parse_optional_vector('100, 200, 300')
 
         self.assert_equal_with_datatype(nrrd.parse_optional_vector('(100, 200, 300)'), [100, 200, 300])
@@ -98,7 +98,7 @@ class TestFieldParsing(unittest.TestCase):
 
         self.assertEqual(nrrd.parse_optional_vector('none'), None)
 
-        with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
             nrrd.parse_optional_vector('(100.47655, 220.32)', dtype=np.uint8)
 
     def test_parse_matrix(self):
@@ -122,7 +122,7 @@ class TestFieldParsing(unittest.TestCase):
         self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=int),
                                         [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-        with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
             nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=np.uint8)
 
     def test_parse_optional_matrix(self):
@@ -150,7 +150,7 @@ class TestFieldParsing(unittest.TestCase):
 
         self.assert_equal_with_datatype(nrrd.parse_number_list('1'), [1])
 
-        with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
+        with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
             nrrd.parse_number_list('1 2 3 4', dtype=np.uint8)
 
     def test_parse_number_auto_dtype(self):
@@ -228,23 +228,23 @@ class TestReadingFunctions(unittest.TestCase):
 
     def test_read_raw_header(self):
         expected_header = {u'type': 'float', u'dimension': 3, u'keyvaluepairs': {}}
-        header = nrrd.read_header(("NRRD0005", "type: float", "dimension: 3"))
+        header = nrrd.read_header(('NRRD0005', 'type: float', 'dimension: 3'))
         self.assertEqual(expected_header, header)
 
         expected_header = {u'keyvaluepairs': {u'my extra info': u'my : colon-separated : values'}}
-        header = nrrd.read_header(("NRRD0005", "my extra info:=my : colon-separated : values"))
+        header = nrrd.read_header(('NRRD0005', 'my extra info:=my : colon-separated : values'))
         self.assertEqual(expected_header, header)
 
 
 class TestWritingFunctions(unittest.TestCase):
     def setUp(self):
-        self.temp_write_dir = tempfile.mkdtemp("nrrdtest")
+        self.temp_write_dir = tempfile.mkdtemp('nrrdtest')
         self.data_input, _ = nrrd.read(RAW_NRRD_FILE_PATH)
         with open(RAW_DATA_FILE_PATH, 'rb') as f:
             self.expected_data = f.read()
 
     def write_and_read_back_with_encoding(self, encoding):
-        output_filename = os.path.join(self.temp_write_dir, "testfile_%s.nrrd" % encoding)
+        output_filename = os.path.join(self.temp_write_dir, 'testfile_%s.nrrd' % encoding)
         nrrd.write(output_filename, self.data_input, {u'encoding': encoding})
         # Read back the same file
         data, header = nrrd.read(output_filename)

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -143,7 +143,6 @@ class TestFieldParsing(unittest.TestCase):
             [[1.4726600000000003, 0, 0], [np.NaN, np.NaN, np.NaN], [0, 1.4726600000000003, 0],
              [0, 0, 4.7619115092114601]])
 
-
     def test_parse_number_list(self):
         self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4'), [1, 2, 3, 4])
         self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4', dtype=float), [1., 2., 3., 4.])
@@ -154,7 +153,9 @@ class TestFieldParsing(unittest.TestCase):
         with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
             nrrd.parse_number_list('1 2 3 4', dtype=np.uint8)
 
-        # print(nrrd.parse_number_auto_dtype('25'))
+    def test_parse_number_auto_dtype(self):
+        self.assertEqual(nrrd.parse_number_auto_dtype('25'), 25)
+        self.assertEqual(nrrd.parse_number_auto_dtype('25.125'), 25.125)
 
 
 class TestReadingFunctions(unittest.TestCase):

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -174,12 +174,12 @@ class TestFieldFormatting(unittest.TestCase):
     def test_format_number(self):
         # Loop through 0 -> 10 in increments of 0.1 and test if the formatted number equals what str(number) returns.
         for x in np.linspace(0.1, 10.0, 100):
-            self.assertEqual(nrrd.format_number(x), repr(x))
+            self.assertEqual(nrrd.format_number(x), repr(x).rstrip('0').rstrip('.'))
 
         # A few example floating points and the resulting output numbers that should be seen
         values = {
             123412341234.123: '123412341234.123',
-            0.000000123123: '1.23123e-07'
+            0.000000123123: '1.2312300000000001e-07'
         }
 
         for key, value in values.items():
@@ -188,55 +188,63 @@ class TestFieldFormatting(unittest.TestCase):
     def test_format_vector(self):
         self.assertEqual(nrrd.format_vector([1, 2, 3]), '(1,2,3)')
         self.assertEqual(nrrd.format_vector([1., 2., 3.]), '(1,2,3)')
-        self.assertEqual(nrrd.format_vector([1.2, 2., 3.2]), '(1.2,2,3.2)')
+        self.assertEqual(nrrd.format_vector([1.2, 2., 3.2]), '(1.2,2,3.2000000000000002)')
 
         self.assertEqual(nrrd.format_vector(np.array([1, 2, 3])), '(1,2,3)')
         self.assertEqual(nrrd.format_vector(np.array([1., 2., 3.])), '(1,2,3)')
-        self.assertEqual(nrrd.format_vector(np.array([1.2, 2., 3.2])), '(1.2,2,3.2)')
+        self.assertEqual(nrrd.format_vector(np.array([1.2, 2., 3.2])), '(1.2,2,3.2000000000000002)')
 
     def test_format_optional_vector(self):
         self.assertEqual(nrrd.format_optional_vector([1, 2, 3]), '(1,2,3)')
         self.assertEqual(nrrd.format_optional_vector([1., 2., 3.]), '(1,2,3)')
-        self.assertEqual(nrrd.format_optional_vector([1.2, 2., 3.2]), '(1.2,2,3.2)')
+        self.assertEqual(nrrd.format_optional_vector([1.2, 2., 3.2]), '(1.2,2,3.2000000000000002)')
 
         self.assertEqual(nrrd.format_optional_vector(np.array([1, 2, 3])), '(1,2,3)')
         self.assertEqual(nrrd.format_optional_vector(np.array([1., 2., 3.])), '(1,2,3)')
-        self.assertEqual(nrrd.format_optional_vector(np.array([1.2, 2., 3.2])), '(1.2,2,3.2)')
+        self.assertEqual(nrrd.format_optional_vector(np.array([1.2, 2., 3.2])), '(1.2,2,3.2000000000000002)')
 
         self.assertEqual(nrrd.format_optional_vector(None), 'none')
+        self.assertEqual(nrrd.format_optional_vector(np.array([np.NaN, np.NaN, np.NaN])), 'none')
+        self.assertEqual(nrrd.format_optional_vector([np.NaN, np.NaN, np.NaN]), 'none')
 
     def test_format_matrix(self):
         self.assertEqual(nrrd.format_matrix(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])), '(1,2,3) (4,5,6) (7,8,9)')
-        # self.assertEqual(nrrd.format_matrix(np.array([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]])), '(1,2,3) (4,5,6) (7,8,9)')
-        # self.assertEqual(nrrd.format_matrix(np.array([[1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]])), '(1,2.2,3.3) (4.4,5.5,6.6) (7.7,8.8,9.9)')
+        self.assertEqual(nrrd.format_matrix(np.array([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]])), '(1,2,3) (4,5,6) '
+                                                                                                   '(7,8,9)')
+        self.assertEqual(nrrd.format_matrix(np.array([[1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]])),
+                         '(1,2.2000000000000002,3.2999999999999998) (4.4000000000000004,5.5,6.5999999999999996) '
+                         '(7.7000000000000002,8.8000000000000007,9.9000000000000004)')
 
-    # def test_parse_matrix(self):
-    #     self.assert_equal_with_datatype(
-    #         nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
-    #         [[1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0], [0, 0, 4.7619115092114601]])
-    #
-    #     self.assert_equal_with_datatype(
-    #         nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)',
-    #                           dtype=float),
-    #         [[1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0], [0, 0, 4.7619115092114601]])
-    #
-    #     self.assert_equal_with_datatype(
-    #         nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)',
-    #                           dtype=int), [[1, 0, 0], [0, 1, 0], [0, 0, 4]])
-    #
-    #     self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)'),
-    #                                     [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-    #     self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=float),
-    #                                     [[1., 0., 0.], [0., 1., 0.], [0., 0., 1.]])
-    #     self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=int),
-    #                                     [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-    #
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'Matrix should have same number of elements in each row'):
-    #         nrrd.parse_matrix('(1,0,0,0) (0,1,0) (0,0,1)')
-    #
-    #     with self.assertRaisesRegex(nrrd.NrrdError, 'dtype should be None for automatic type detection, float or int'):
-    #         nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=np.uint8)
-    #
+        self.assertEqual(nrrd.format_matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), '(1,2,3) (4,5,6) (7,8,9)')
+        self.assertEqual(nrrd.format_matrix([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]), '(1,2,3) (4,5,6) '
+                                                                                                   '(7,8,9)')
+        self.assertEqual(nrrd.format_matrix([[1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]]),
+                         '(1,2.2000000000000002,3.2999999999999998) (4.4000000000000004,5.5,6.5999999999999996) '
+                         '(7.7000000000000002,8.8000000000000007,9.9000000000000004)')
+
+    def test_format_optional_matrix(self):
+        self.assertEqual(nrrd.format_optional_matrix(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])),
+                         '(1,2,3) (4,5,6) (7,8,9)')
+        self.assertEqual(nrrd.format_optional_matrix(np.array([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]])),
+                         '(1,2,3) (4,5,6) (7,8,9)')
+        self.assertEqual(nrrd.format_optional_matrix(np.array([[1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]])),
+                         '(1,2.2000000000000002,3.2999999999999998) (4.4000000000000004,5.5,6.5999999999999996) '
+                         '(7.7000000000000002,8.8000000000000007,9.9000000000000004)')
+
+        self.assertEqual(nrrd.format_optional_matrix([[1, 2, 3], [4, 5, 6], [7, 8, 9]]), '(1,2,3) (4,5,6) (7,8,9)')
+        self.assertEqual(nrrd.format_optional_matrix([[1., 2., 3.], [4., 5., 6.], [7., 8., 9.]]),
+                         '(1,2,3) (4,5,6) (7,8,9)')
+        self.assertEqual(nrrd.format_optional_matrix([[1, 2.2, 3.3], [4.4, 5.5, 6.6], [7.7, 8.8, 9.9]]),
+                         '(1,2.2000000000000002,3.2999999999999998) (4.4000000000000004,5.5,6.5999999999999996) '
+                         '(7.7000000000000002,8.8000000000000007,9.9000000000000004)')
+
+        self.assertEqual(nrrd.format_optional_matrix(np.array([
+                         [np.NaN, np.NaN, np.NaN], [1, 2, 3], [4, 5, 6], [7, 8, 9]])),
+                         'none (1,2,3) (4,5,6) (7,8,9)')
+        self.assertEqual(nrrd.format_optional_matrix(np.array([
+                         [1, 2, 3], [np.NaN, np.NaN, np.NaN], [4, 5, 6], [7, 8, 9]])),
+                         '(1,2,3) none (4,5,6) (7,8,9)')
+
     # def test_parse_optional_matrix(self):
     #     self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
     #         '(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -59,6 +59,9 @@ class TestFieldParsing(unittest.TestCase):
         self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32)', dtype=float), [100.47655, 220.32])
         self.assert_equal_with_datatype(nrrd.parse_vector('(100.47655, 220.32)', dtype=int), [100, 220])
 
+        with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
+            nrrd.parse_vector('(100.47655, 220.32)', dtype=np.uint8)
+
     def test_parse_optional_vector(self):
         with self.assertRaisesRegex(nrrd.NrrdError, "Vector should be enclosed by parentheses."):
             nrrd.parse_optional_vector('100, 200, 300)')
@@ -95,6 +98,9 @@ class TestFieldParsing(unittest.TestCase):
 
         self.assertEqual(nrrd.parse_optional_vector('none'), None)
 
+        with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
+            nrrd.parse_optional_vector('(100.47655, 220.32)', dtype=np.uint8)
+
     def test_parse_matrix(self):
         self.assert_equal_with_datatype(
             nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
@@ -116,6 +122,9 @@ class TestFieldParsing(unittest.TestCase):
         self.assert_equal_with_datatype(nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=int),
                                         [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
+        with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
+            nrrd.parse_matrix('(1,0,0) (0,1,0) (0,0,1)', dtype=np.uint8)
+
     def test_parse_optional_matrix(self):
         self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
             '(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
@@ -134,14 +143,16 @@ class TestFieldParsing(unittest.TestCase):
             [[1.4726600000000003, 0, 0], [np.NaN, np.NaN, np.NaN], [0, 1.4726600000000003, 0],
              [0, 0, 4.7619115092114601]])
 
-        # Test parse_matrix function
-        # print(nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'))
-        # print(nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)', dtype=int))
-        # print(nrrd.parse_matrix('(1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)', dtype=float))
 
-        # print(nrrd.parse_optional_matrix('none (1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'))
+    def test_parse_number_list(self):
+        self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4'), [1, 2, 3, 4])
+        self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4', dtype=float), [1., 2., 3., 4.])
+        self.assert_equal_with_datatype(nrrd.parse_number_list('1 2 3 4', dtype=int), [1, 2, 3, 4])
 
-        # print(nrrd.parse_number_list('25 0 30 100 24 34'))
+        self.assert_equal_with_datatype(nrrd.parse_number_list('1'), [1])
+
+        with self.assertRaisesRegex(nrrd.NrrdError, "dtype should be None for automatic type detection, float or int"):
+            nrrd.parse_number_list('1 2 3 4', dtype=np.uint8)
 
         # print(nrrd.parse_number_auto_dtype('25'))
 


### PR DESCRIPTION
This is sort of discussed in #37

Added new functions for parsing (converting from NRRD string to Python equivalent type) and formatting (conversion from Python equivalent type to NRRD string). These are public functions (no underscore before them), neatly organized and well-documented so users will know how to use the functions.

The purpose of having these functions is that it is quite common to add custom fields to the NRRD header for some reason and you may want to parse these fields. A great example is 3D Slicer for their segmentation NRRD files that add a bunch of fields.

The following NRRD types are defined as follows: (I've excluded any basic types like int, float, str or str list because they are pretty basic to convert to/from):
* vector - (1,2,3,4)
* optional vector - (1,2,3,4) or none
* matrix - (1,2,3) (4,5,6) (7,8,9)
* optional matrix - none (1,2,3) (4,5,6) (7,8,9)
* number list - 5 4 3 2 1

Each function is named using underscores and prefixed with parse or format depending on which method you want to use. 

Previously, a vector, matrix or number list would return a Python list of numbers. This is changed to convert to a Numpy array. I think this will be worthwhile because most of the time the user will want the extended functionality that Numpy has for numerical arrays.

**Note:** A small change I made to the formatting of numbers is changing .17f to .17g. The former option (f) prints 17 decimal points while the latter prints 17 significant digits. The g option is correct because 17 significant digits is the resolution of a 64-bit float. 

An example:

This is a 17 significant digit number:
`12.312312312312312`

This is what the f format specifier would print:

`12.312312312312312XX` where the last two digits would be random numbers and incorrect