### PR TITLE
Hyperlink DOI against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/mhe/pynrrd.svg?branch=master)](https://travis-ci.org/mhe/pynrrd)
-[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.62065.svg)](http://dx.doi.org/10.5281/zenodo.62065)
+[![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.62065.svg)](https://doi.org/10.5281/zenodo.62065)
 
 pynrrd
 ======


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8) and Zenodo started using it for its badges as well.

Cheers!