### PR TITLE
parse_optional_matrix does not take 'dtype' kwarg

### DIFF
--- a/nrrd.py
+++ b/nrrd.py
@@ -529,7 +529,7 @@ _NRRD_FIELD_PARSERS = {
     'space units': lambda fieldValue: [str(x) for x in fieldValue.split()],
     'space origin': lambda fieldValue: parse_vector(fieldValue, dtype=float),
     'space directions': lambda fieldValue: parse_optional_matrix(fieldValue),
-    'measurement frame': lambda fieldValue: parse_optional_matrix(fieldValue, dtype=int),
+    'measurement frame': lambda fieldValue: parse_optional_matrix(fieldValue),
 }
 
 _NRRD_FIELD_FORMATTERS = {

--- a/tests/test_nrrd.py
+++ b/tests/test_nrrd.py
@@ -17,6 +17,7 @@ RAW_DATA_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30.raw')
 GZ_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_gz.nrrd')
 BZ2_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_bz2.nrrd')
 GZ_LINESKIP_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'BallBinary30x30x30_gz_lineskip.nrrd')
+RAW_4D_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'test_simple4d_raw.nrrd')
 
 ASCII_1D_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'test1d_ascii.nrrd')
 ASCII_2D_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'test2d_ascii.nrrd')
@@ -368,6 +369,27 @@ class TestReadingFunctions(unittest.TestCase):
         np.testing.assert_equal(data.dtype, np.uint16)
         np.testing.assert_equal(data, np.arange(1, 28).reshape(3, 9, order='F'))
 
+    def test_read_simple_4d_nrrd(self):
+        expected_header = {'keyvaluepairs': {},
+                           'type': 'double',
+                           'dimension': 4,
+                           'space': 'right-anterior-superior',
+                           'sizes': np.array([1, 1, 1, 1]),
+                           'space directions': np.array([[1.5, 0. , 0. ],
+                                                         [0. , 1.5, 0. ],
+                                                         [0. , 0. , 1. ],
+                                                         [np.NaN, np.NaN, np.NaN]]),
+                           'endian': 'little',
+                           'encoding': 'raw',
+                           'measurement frame': np.array([[1., 0., 0.],
+                                                          [0., 1., 0.],
+                                                          [0., 0., 1.]])}
+
+        data, header = nrrd.read(RAW_4D_NRRD_FILE_PATH)
+
+        np.testing.assert_equal(header, expected_header)
+        np.testing.assert_equal(data.dtype, np.float64)
+        np.testing.assert_equal(data, np.array([[[[0.76903426]]]]))
 
 class TestWritingFunctions(unittest.TestCase):
     def setUp(self):

--- a/tests/test_simple4d_raw.nrrd
+++ b/tests/test_simple4d_raw.nrrd
@@ -1,0 +1,13 @@
+NRRD0005
+# Complete NRRD file format specification at:
+# http://teem.sourceforge.net/nrrd/format.html
+type: double
+dimension: 4
+space: right-anterior-superior
+sizes: 1 1 1 1
+space directions: (1.5,0,0) (0,1.5,0) (0,0,1) none
+endian: little
+encoding: raw
+measurement frame: (1,0,0) (0,1,0) (0,0,1)
+
+’ƒ†¼í›è?


### PR DESCRIPTION
Perhaps it should? But it is currently only used for two fields, both of which should always parse as floats.