### PR TITLE
Set minimum version for Numpy library to 1.11.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-# TODO: Minimum numpy version? 
-numpy
+numpy>=1.11.1

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='pynrrd',
       url='https://github.com/mhe/pynrrd',
       py_modules=['nrrd'],
       license='MIT License',
-      install_requires=['numpy'],
+      install_requires=['numpy>=1.11.1'],
       keywords='nrrd teem image processing file format',
       classifiers=[
           'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
This was experimentally found to be a version of Numpy that successfully runs the pynrrd tests. It is likely that earlier versions of Numpy may work but the cutoff was just set here.