### PR TITLE
Add numpydoc requirement for readthedocs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy>=1.11.1
+numpydoc


### PR DESCRIPTION
The numpydoc package is used to support Numpy style docstrings in the pynrrd project. This is not installed on readthedocs and must be installed via requirements.txt file