### PR TITLE
Add support for codecov support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
 # Command to install dependencies
 install:
   - pip install -r requirements.txt
+  - pip install --user codecov
 
 # Command to run tests
 script: python -m unittest discover -v nrrd/tests
@@ -22,3 +23,5 @@ deploy:
     tags: true
     python: 3.4
 
+after_success:
+  - codecov


### PR DESCRIPTION
@mhe setup codecov with the repository and now adding a few changes to Travis CI to integrate with Codecov.

Reference: https://github.com/codecov/codecov-python/blob/master/README.md#ci-providers