### PR TITLE
Allow override of dup. field error, and zlib compression level

### DIFF
--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -255,7 +255,7 @@ def read_header(file, custom_field_map=None):
 
         # Check if the field has been added already
         if field in header.keys():
-            dup_message = 'Duplicate header field: %s' % repr(field)
+            dup_message = "Duplicate header field: '%s'" % str(field)
 
             if not _NRRD_ALLOW_DUPLICATE_FIELD:
                 raise NRRDError(dup_message)

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -18,7 +18,7 @@ _NRRD_REQUIRED_FIELDS = ['dimension', 'type', 'encoding', 'sizes']
 
 # Duplicated fields are prohibited by the spec, but do occur in the wild.
 # Set True to allow duplicate fields, with a warning.
-_NRRD_ALLOW_DUPLICATE_FIELD = False
+ALLOW_DUPLICATE_FIELD = False
 
 _TYPEMAP_NRRD2NUMPY = {
     'signed char': 'i1',
@@ -257,7 +257,7 @@ def read_header(file, custom_field_map=None):
         if field in header.keys():
             dup_message = "Duplicate header field: '%s'" % str(field)
 
-            if not _NRRD_ALLOW_DUPLICATE_FIELD:
+            if not ALLOW_DUPLICATE_FIELD:
                 raise NRRDError(dup_message)
 
             warnings.warn(dup_message)

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -104,21 +104,18 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header = {u'type': 'float', u'dimension': 3}
         header_txt_tuple = ('NRRD0005', 'type: float', 'dimension: 3', 'type: float')
 
-        dup_message = "Duplicate header field: 'type'"
-        try:
+        with self.assertRaisesRegex(nrrd.NRRDError, "Duplicate header field: 'type'"):
             header = nrrd.read_header(header_txt_tuple)
-        except nrrd.NRRDError as e:
-            self.assertEqual(e.args[0], dup_message)
 
         import warnings
         with warnings.catch_warnings(record=True) as w:
             nrrd.reader._NRRD_ALLOW_DUPLICATE_FIELD = True
             header = nrrd.read_header(header_txt_tuple)
 
-            self.assertEqual(len(w), 1)
-            self.assertTrue("Duplicate header field:" in str(w[0].message))
+            self.assertTrue("Duplicate header field: 'type'" in str(w[0].message))
 
             self.assertEqual(expected_header, header)
+            nrrd.reader._NRRD_ALLOW_DUPLICATE_FIELD = False
 
     def test_read_header_and_ascii_1d_data(self):
         expected_header = {u'dimension': 1,

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -116,7 +116,7 @@ class TestReadingFunctions(unittest.TestCase):
             header = nrrd.read_header(header_txt_tuple)
 
             self.assertEqual(len(w), 1)
-            self.assertTrue("Duplicate header field: 'type'" == str(w[0].message))
+            self.assertTrue("Duplicate header field:" in str(w[0].message))
 
             self.assertEqual(expected_header, header)
 

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -109,7 +109,7 @@ class TestReadingFunctions(unittest.TestCase):
 
         import warnings
         with warnings.catch_warnings(record=True) as w:
-            nrrd.reader._NRRD_ALLOW_DUPLICATE_FIELD = True
+            nrrd.reader.ALLOW_DUPLICATE_FIELD = True
             header = nrrd.read_header(header_txt_tuple)
 
             self.assertTrue("Duplicate header field: 'type'" in str(w[0].message))

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -248,7 +248,7 @@ def write(filename, data, header={}, detached_header=False, custom_field_map=Non
             _write_data(data, data_fh, header, compression_level=compression_level)
 
 
-def _write_data(data, fh, header, compression_level = 9):
+def _write_data(data, fh, header, compression_level = None):
     if header['encoding'] == 'raw':
         # Convert the data into a string
         raw_data = data.tostring(order='F')

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -14,6 +14,10 @@ from nrrd.reader import _get_field_type
 # further. The following two values define the size of the chunks.
 _WRITE_CHUNKSIZE = 2 ** 20
 
+# Controls zlib compression level when saving.
+# valid levels are -1 to 9 (see zlib module documentation)
+_ZLIB_LEVEL = 9
+
 _NRRD_FIELD_ORDER = [
     'type',
     'dimension',
@@ -66,7 +70,6 @@ _NUMPY2NRRD_ENDIAN_MAP = {
     '>': 'big',
     'B': 'big'
 }
-
 
 def _format_field_value(value, field_type):
     if field_type == 'int':
@@ -263,7 +266,7 @@ def _write_data(data, fh, header):
 
         # Construct the compressor object based on encoding
         if header['encoding'] in ['gzip', 'gz']:
-            compressobj = zlib.compressobj(9, zlib.DEFLATED, zlib.MAX_WBITS | 16)
+            compressobj = zlib.compressobj(_ZLIB_LEVEL, zlib.DEFLATED, zlib.MAX_WBITS | 16)
         elif header['encoding'] in ['bzip2', 'bz2']:
             compressobj = bz2.BZ2Compressor()
         else:

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -124,8 +124,8 @@ def write(filename, data, header={}, detached_header=False, custom_field_map=Non
     custom_field_map : :class:`dict` (:class:`str`, :class:`str`), optional
         Dictionary used for parsing custom field types where the key is the custom field name and the value is a
         string identifying datatype for the custom field.
-    compression_level : int
-        Int specifying compression level, when applicable.
+    compression_level : :class:`int`
+        Int specifying compression level, when using a compressed encoding (.gz, .bz2).
         - For zlib (.gz): 1-9 set low to high compression; 0 disables; -1 uses zlib default.
         - For bzip2 (.bz2): 1-9 set low to high compression.
 
@@ -269,7 +269,7 @@ def _write_data(data, fh, header, compression_level = 9):
         if header['encoding'] in ['gzip', 'gz']:
             compressobj = zlib.compressobj(compression_level, zlib.DEFLATED, zlib.MAX_WBITS | 16)
         elif header['encoding'] in ['bzip2', 'bz2']:
-            compressobj = bz2.BZ2Compressor()
+            compressobj = bz2.BZ2Compressor(compression_level)
         else:
             raise NRRDError('Unsupported encoding: "%s"' % header['encoding'])
 


### PR DESCRIPTION
- Allow override of duplicate field error, with a warning instead (occasionally occur with buggy writers)

- Allow changing the compression level - can significantly improve write performance at minimal space cost. As an illustrative example:


<details>
<summary>timing test details</summary>

```python
import nrrd
nrrd.reader._NRRD_ALLOW_DUPLICATE_FIELD = True
```


```python
img,hdr = nrrd.read("/path/to/dwi.nhdr")
%timeit -n1 -r1 nrrd.write("test.nrrd", img, hdr)
```

    193 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)



```python
hdr['encoding'] = 'gz'
%timeit -n1 -r1 nrrd.write("test_zl_9.nrrd", img, hdr)
```

    20.2 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

```python
nrrd.writer._ZLIB_LEVEL = -1
hdr['encoding'] = 'gz'
%timeit -n1 -r1 nrrd.write("test_zl_default.nrrd", img, hdr)
```

    9.94 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)



```python
nrrd.writer._ZLIB_LEVEL = 1
hdr['encoding'] = 'gz'
%timeit -n1 -r1 nrrd.write("test_zl_1.nrrd", img, hdr)
```

    2.68 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

</details>
<br><br>

Output files below (test.nrrd is original, and zl_default is roughly level 6 per the docs):
```python
!ls -lah *.nrrd

    -rw-r--r--  1 inorton  staff    61M Aug 24 16:38 test.nrrd
    -rw-r--r--  1 inorton  staff    27M Aug 24 16:39 test_zl_1.nrrd
    -rw-r--r--  1 inorton  staff    26M Aug 24 16:38 test_zl_9.nrrd
    -rw-r--r--  1 inorton  staff    26M Aug 24 16:38 test_zl_default.nrrd
```

So, level 9 is ~10x slower than level 1, but saves only 1 MB. This is brain MRI data.