### PR TITLE
Allow Numpy data to be written for compressed data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/*
 *.egg-info/*
 MANIFEST
 .idea/*
+.cache
 
 # Sphinx documentation
 docs/build/

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -380,7 +380,7 @@ def read_data(header, fh=None, filename=None):
 
         # Byte skip is applied AFTER the decompression. Skip first x bytes of the decompressed data and parse it using
         # NumPy
-        data = np.frombuffer(decompressed_data[byte_skip:], dtype)
+        data = np.fromstring(decompressed_data[byte_skip:], dtype)
 
     # Close the file
     # Even if opened using with keyword, closing it does not hurt

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -146,6 +146,9 @@ class TestReadingFunctions(unittest.TestCase):
         np.testing.assert_equal(data.dtype, np.uint8)
         np.testing.assert_equal(data, np.arange(1, 28))
 
+        # Test that the data read is able to be edited
+        self.assertTrue(data.flags['WRITEABLE'])
+
     def test_read_header_and_ascii_2d_data(self):
         expected_header = {u'dimension': 2,
                            u'encoding': 'ASCII',
@@ -159,6 +162,9 @@ class TestReadingFunctions(unittest.TestCase):
         np.testing.assert_equal(header, expected_header)
         np.testing.assert_equal(data.dtype, np.uint16)
         np.testing.assert_equal(data, np.arange(1, 28).reshape(3, 9, order='F'))
+
+        # Test that the data read is able to be edited
+        self.assertTrue(data.flags['WRITEABLE'])
 
     def test_read_simple_4d_nrrd(self):
         expected_header = {'type': 'double',
@@ -180,6 +186,9 @@ class TestReadingFunctions(unittest.TestCase):
         np.testing.assert_equal(header, expected_header)
         np.testing.assert_equal(data.dtype, np.float64)
         np.testing.assert_equal(data, np.array([[[[0.76903426]]]]))
+
+        # Test that the data read is able to be edited
+        self.assertTrue(data.flags['WRITEABLE'])
 
     def test_custom_fields_without_field_map(self):
         expected_header = {u'dimension': 1,

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -54,6 +54,9 @@ class TestReadingFunctions(unittest.TestCase):
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
 
+        # Test that the data read is able to be edited
+        self.assertTrue(data.flags['WRITEABLE'])
+
     def test_read_detached_header_and_data(self):
         expected_header = self.expected_header
         expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
@@ -62,6 +65,9 @@ class TestReadingFunctions(unittest.TestCase):
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
+
+        # Test that the data read is able to be edited
+        self.assertTrue(data.flags['WRITEABLE'])
 
     def test_read_header_and_gz_compressed_data(self):
         expected_header = self.expected_header
@@ -72,6 +78,9 @@ class TestReadingFunctions(unittest.TestCase):
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
 
+        # Test that the data read is able to be edited
+        self.assertTrue(data.flags['WRITEABLE'])
+
     def test_read_header_and_bz2_compressed_data(self):
         expected_header = self.expected_header
         expected_header[u'encoding'] = 'bzip2'
@@ -80,6 +89,9 @@ class TestReadingFunctions(unittest.TestCase):
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
+
+        # Test that the data read is able to be edited
+        self.assertTrue(data.flags['WRITEABLE'])
 
     def test_read_header_and_gz_compressed_data_with_lineskip3(self):
         expected_header = self.expected_header
@@ -90,6 +102,9 @@ class TestReadingFunctions(unittest.TestCase):
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
+
+        # Test that the data read is able to be edited
+        self.assertTrue(data.flags['WRITEABLE'])
 
     def test_read_raw_header(self):
         expected_header = {u'type': 'float', u'dimension': 3}


### PR DESCRIPTION
When reading compressed data in pynrrd, the resulting numpy array is not writeable. This PR fixes the issue.