### PR TITLE
Update the documentation with ALLOW_DUPLICATE_FIELD 

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -68,10 +68,10 @@ Example reading NRRD file with duplicated header
 
     import nrrd
 
-    # set this field to True to enable the reading of files with duplicated header
+    # set this field to True to enable the reading of files with duplicated header fields
     nrrd.reader.ALLOW_DUPLICATE_FIELD = True
 
-    #name of the file you want to read with a duplicated header
+    #name of the file you want to read with a duplicated header field
     filename = "filename.nrrd"
 
     #read the file

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -68,14 +68,15 @@ Example reading NRRD file with duplicated header field
 
     import nrrd
 
-    # set this field to True to enable the reading of files with duplicated header fields
+    # Set this field to True to enable the reading of files with duplicated header fields
     nrrd.reader.ALLOW_DUPLICATE_FIELD = True
 
-    #name of the file you want to read with a duplicated header field
+    # Name of the file you want to read with a duplicated header field
     filename = "filename.nrrd"
 
-    #read the file
+    # Read the file
     # filedata = numpy array
     # fileheader = header of the NRRD file
+    # A warning is now received about duplicate headers rather than an error being thrown
     filedata, fileheader = nrrd.read(filename)
     >>> UserWarning: Duplicate header field: 'space' warnings.warn(dup_message)

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -62,7 +62,7 @@ Example with fields and custom fields
        [0., 1., 0.],
        [0., 0., 1.]])), ('kinds', ['domain', 'domain', 'domain']), ('encoding', 'ASCII'), ('spacings', array([1.0458, 1.0458, 2.5   ])), ('units', ['mm', 'mm', 'mm']), ('custom_field_here1', 24.34), ('custom_field_here2', array([1, 2, 3, 4]))])
 
-Example reading NRRD file with duplicated header
+Example reading NRRD file with duplicated header field
 -------------
 .. code-block:: python
 

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -62,3 +62,20 @@ Example with fields and custom fields
        [0., 1., 0.],
        [0., 0., 1.]])), ('kinds', ['domain', 'domain', 'domain']), ('encoding', 'ASCII'), ('spacings', array([1.0458, 1.0458, 2.5   ])), ('units', ['mm', 'mm', 'mm']), ('custom_field_here1', 24.34), ('custom_field_here2', array([1, 2, 3, 4]))])
 
+Example reading NRRD file with duplicated header
+-------------
+.. code-block:: python
+
+    import nrrd
+
+    # set this field to True to enable the reading of files with duplicated header
+    nrrd.reader.ALLOW_DUPLICATE_FIELD = True
+
+    #name of the file you want to read with a duplicated header
+    filename = "filename.nrrd"
+
+    #read the file
+    # filedata = numpy array
+    # fileheader = header of the NRRD file
+    filedata, fileheader = nrrd.read(filename)
+    >>> UserWarning: Duplicate header field: 'space' warnings.warn(dup_message)

--- a/docs/source/pynrrd.rst
+++ b/docs/source/pynrrd.rst
@@ -11,6 +11,7 @@ Reading NRRD files
     nrrd.read
     nrrd.read_header
     nrrd.read_data
+    nrrd.reader.ALLOW_DUPLICATE_FIELD
 
 Writing NRRD files
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/pynrrd.rst
+++ b/docs/source/pynrrd.rst
@@ -48,3 +48,5 @@ NRRD Module
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. autodata:: nrrd.reader.ALLOW_DUPLICATE_FIELD

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -188,7 +188,7 @@ The :obj:`file` parameter of :meth:`read_header` accepts a filename or a string 
 
 The :meth:`read_data` will not typically be used besides within the :meth:`read` function because the header is a required parameter (:obj:`header`) to this function. The remaining two parameters :obj:`fh` and :obj:`filename` are optional depending on the parameters but it never hurts to specify both. The file handle (:obj:`fh`) is necessary if the header contains the NRRD data as well (AKA it is not a detached file). However, if the NRRD data is detached from the header, then the :obj:`filename` parameter is required to obtain the absolute path to the data file. The :meth:`read_data` function returns a :class:`numpy.ndarray` of the data.
 
-Some NRRD files, while prohibited by specification, may contain duplicated reader fields preventing the proper reading of the file. Changing :const:`ALLOW_DUPLICATE_FIELD` to 'True' will show a warning instead of an error while trying to read the file.
+Some NRRD files, while prohibited by specification, may contain duplicated reader fields preventing the proper reading of the file. Changing :data:`nrrd.reader.ALLOW_DUPLICATE_FIELD` to :obj:`True` will show a warning instead of an error while trying to read the file.
 
 Writing NRRD files
 ------------------

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -188,6 +188,8 @@ The :obj:`file` parameter of :meth:`read_header` accepts a filename or a string 
 
 The :meth:`read_data` will not typically be used besides within the :meth:`read` function because the header is a required parameter (:obj:`header`) to this function. The remaining two parameters :obj:`fh` and :obj:`filename` are optional depending on the parameters but it never hurts to specify both. The file handle (:obj:`fh`) is necessary if the header contains the NRRD data as well (AKA it is not a detached file). However, if the NRRD data is detached from the header, then the :obj:`filename` parameter is required to obtain the absolute path to the data file. The :meth:`read_data` function returns a :class:`numpy.ndarray` of the data.
 
+Some NRRD files, while prohibited by specification, may contain duplicated readers and that can prevent the reading of the file. Changing :const:`ALLOW_DUPLICATE_FIELD` to 'True' will show a warning instead of an error.
+
 Writing NRRD files
 ------------------
 Writing to NRRD files can be done with the single function :meth:`write`. The :obj:`filename` parameter to the function specifies the absolute or relative filename to write the NRRD file. If the :obj:`filename` extension is .nhdr, then the :obj:`detached_header` parameter is set to true automatically. If the :obj:`detached_header` parameter is set to :obj:`True` and the :obj:`filename` ends in .nrrd, then the header file will have the same path and base name as the :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -188,7 +188,7 @@ The :obj:`file` parameter of :meth:`read_header` accepts a filename or a string 
 
 The :meth:`read_data` will not typically be used besides within the :meth:`read` function because the header is a required parameter (:obj:`header`) to this function. The remaining two parameters :obj:`fh` and :obj:`filename` are optional depending on the parameters but it never hurts to specify both. The file handle (:obj:`fh`) is necessary if the header contains the NRRD data as well (AKA it is not a detached file). However, if the NRRD data is detached from the header, then the :obj:`filename` parameter is required to obtain the absolute path to the data file. The :meth:`read_data` function returns a :class:`numpy.ndarray` of the data.
 
-Some NRRD files, while prohibited by specification, may contain duplicated readers and that can prevent the reading of the file. Changing :const:`ALLOW_DUPLICATE_FIELD` to 'True' will show a warning instead of an error.
+Some NRRD files, while prohibited by specification, may contain duplicated reader fields preventing the proper reading of the file. Changing :const:`ALLOW_DUPLICATE_FIELD` to 'True' will show a warning instead of an error while trying to read the file.
 
 Writing NRRD files
 ------------------

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -2,8 +2,8 @@
 import bz2
 import os
 import re
-import zlib
 import warnings
+import zlib
 from collections import OrderedDict
 
 from nrrd.parsers import *
@@ -16,27 +16,26 @@ _READ_CHUNKSIZE = 2 ** 20
 
 _NRRD_REQUIRED_FIELDS = ['dimension', 'type', 'encoding', 'sizes']
 
-# Duplicated fields are prohibited by the spec, but do occur in the wild.
-# Set True to allow duplicate fields, with a warning.
 ALLOW_DUPLICATE_FIELD = False
-"""
-When there are duplicated fields on a 'NRRD' file header, pynrrd throws an error by default.
-Setting this field as 'True' will instead show a warning.
+"""Allow duplicate header fields when reading NRRD files
+
+When there are duplicated fields in a NRRD file header, pynrrd throws an error by default. Setting this field as 
+:obj:`True` will instead show a warning.
 
 Example:
-    Reading a NRRD file with duplicated header field 'space'.
+    Reading a NRRD file with duplicated header field 'space' with field set to :obj:`False`.
 
-    >>> filedata, fileheader = nrrd.read(filename_duplicatedheader.nrrd)
+    >>> filedata, fileheader = nrrd.read('filename_duplicatedheader.nrrd')
     nrrd.errors.NRRDError: Duplicate header field: 'space'
 
-    Set the field as True to receive a warning.
+    Set the field as :obj:`True` to receive a warning instead.
 
     >>> nrrd.reader.ALLOW_DUPLICATE_FIELD = True
-    >>> filedata, fileheader = nrrd.read(filename_duplicatedheader.nrrd)
+    >>> filedata, fileheader = nrrd.read('filename_duplicatedheader.nrrd')
     UserWarning: Duplicate header field: 'space' warnings.warn(dup_message)
 
 Note:
-    Duplicated fields are prohibited by NRRD file specification
+    Duplicated fields are prohibited by the NRRD file specification.
 """
 
 _TYPEMAP_NRRD2NUMPY = {

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -24,7 +24,7 @@ When there are duplicated fields on a 'NRRD' file header, pynrrd throws an error
 Setting this field as 'True' will instead show a warning.
 
 Example:
-    Reading a NRRD file with duplicated header 'space'.
+    Reading a NRRD file with duplicated header field 'space'.
 
     >>> filedata, fileheader = nrrd.read(filename_duplicatedheader.nrrd)
     nrrd.errors.NRRDError: Duplicate header field: 'space'

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -19,6 +19,25 @@ _NRRD_REQUIRED_FIELDS = ['dimension', 'type', 'encoding', 'sizes']
 # Duplicated fields are prohibited by the spec, but do occur in the wild.
 # Set True to allow duplicate fields, with a warning.
 ALLOW_DUPLICATE_FIELD = False
+"""
+When there are duplicated fields on a 'NRRD' file header, pynrrd throws an error by default.
+Setting this field as 'True' will instead show a warning.
+
+Example:
+    Reading a NRRD file with duplicated header 'space'.
+
+    >>> filedata, fileheader = nrrd.read(filename_duplicatedheader.nrrd)
+    nrrd.errors.NRRDError: Duplicate header field: 'space'
+
+    Set the field as True to receive a warning.
+
+    >>> nrrd.reader.ALLOW_DUPLICATE_FIELD = True
+    >>> filedata, fileheader = nrrd.read(filename_duplicatedheader.nrrd)
+    UserWarning: Duplicate header field: 'space' warnings.warn(dup_message)
+
+Note:
+    Duplicated fields are prohibited by NRRD file specification
+"""
 
 _TYPEMAP_NRRD2NUMPY = {
     'signed char': 'i1',

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -130,7 +130,7 @@ class TestReadingFunctions(unittest.TestCase):
             self.assertTrue("Duplicate header field: 'type'" in str(w[0].message))
 
             self.assertEqual(expected_header, header)
-            nrrd.reader._NRRD_ALLOW_DUPLICATE_FIELD = False
+            nrrd.reader.ALLOW_DUPLICATE_FIELD = False
 
     def test_read_header_and_ascii_1d_data(self):
         expected_header = {u'dimension': 1,


### PR DESCRIPTION
Documentation update to include the ALLOW_DUPLICATE_FIELD information (#71 )

I am not used to Sphinx, but I update it using the sphinx-doc by hand.
http://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html 

I hope it is close to the expected.
