### PR TITLE
Fixed anti-pattern in writer function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Ali Ghayoor
 Addison Elliott
 Isaiah Norton
 Tashrif Billah
+Simon Ekström

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -28,6 +28,14 @@ class TestWritingFunctions(unittest.TestCase):
 
         return output_filename
 
+    def test_write_default_header(self):
+        output_filename = os.path.join(self.temp_write_dir, 'testfile_default_header.nrrd')
+        nrrd.write(output_filename, self.data_input)
+
+        # Read back the same file
+        data, header = nrrd.read(output_filename)
+        self.assertEqual(self.expected_data, data.tostring(order='F'))
+
     def test_write_raw(self):
         self.write_and_read_back_with_encoding(u'raw')
 

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -93,7 +93,7 @@ def _format_field_value(value, field_type):
         raise NRRDError('Invalid field type given: %s' % field_type)
 
 
-def write(filename, data, header={}, detached_header=False, relative_data_path=True, custom_field_map=None,
+def write(filename, data, header=None, detached_header=False, relative_data_path=True, custom_field_map=None,
                           compression_level=9):
     """Write :class:`numpy.ndarray` to NRRD file
 
@@ -137,6 +137,9 @@ def write(filename, data, header={}, detached_header=False, relative_data_path=T
     --------
     :meth:`read`, :meth:`read_header`, :meth:`read_data`
     """
+
+    if header is None:
+        header = {}
 
     # Infer a number of fields from the NumPy array and overwrite values in the header dictionary.
     # Get type string identifier from the NumPy datatype


### PR DESCRIPTION
Fixed a bug in the writer function where the header data was persistent between calls (see [this](https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html) for further info).