### PR TITLE
Add parameter for changing index order

### DIFF
--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -182,6 +182,8 @@ Reading NRRD files
 ------------------
 There are three functions that are used to read NRRD files: :meth:`read`, :meth:`read_header` and :meth:`read_data`. :meth:`read` is a convenience function that opens the file located at :obj:`filename` and calls :meth:`read_header` and :meth:`read_data` in succession and returns the data and header.
 
+Reading NRRD files using :meth:`read` or :meth:`read_data` will by default return arrays being indexed in Fortran order, i.e array elements are accessed by `data[x,y,z]`. This differs to the C-order, i.e. `data[z,y,x]`, which is more common in numpy. The :obj:`index_order` parameter can be used to specify which index ordering should be used on the returned array ('C' or 'F'). The :obj:`index_order` parameter needs to be consistent with the parameter of same name in :meth:`write`.
+
 The :meth:`read` and :meth:`read_header` methods accept an optional parameter :obj:`custom_field_map` for parsing custom field types not listed in `Supported Fields`_ of the header. It is a :class:`dict` where the key is the custom field name and the value is a string identifying datatype for the custom field. See `Header datatypes`_ for a list of supported datatypes.
 
 The :obj:`file` parameter of :meth:`read_header` accepts a filename or a string iterator object to read the header from. If a filename is specified, then the file will be opened and closed after the header is read from it. If not specifying a filename, the :obj:`file` parameter can be any sort of iterator that returns a string each time :meth:`next` is called. The two common objects that meet these requirements are file objects and a list of strings. The :meth:`read_header` function returns a :class:`dict` with the field and parsed values as keys and values to the dictionary.
@@ -194,7 +196,7 @@ Writing NRRD files
 ------------------
 Writing to NRRD files can be done with the single function :meth:`write`. The :obj:`filename` parameter to the function specifies the absolute or relative filename to write the NRRD file. If the :obj:`filename` extension is .nhdr, then the :obj:`detached_header` parameter is set to true automatically. If the :obj:`detached_header` parameter is set to :obj:`True` and the :obj:`filename` ends in .nrrd, then the header file will have the same path and base name as the :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.
 
-The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:`header` is an optional parameter of type :class:`dict` containing the field/values to be saved to the NRRD file. 
+The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:`header` is an optional parameter of type :class:`dict` containing the field/values to be saved to the NRRD file. :obj:`index_order` specifies the index order of the array :obj:`data`, this should be consistent with the argument of the same name in :meth:`read`.
 
 .. note::
 
@@ -203,3 +205,7 @@ The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:
 .. note::
 
     The default encoding field used if not specified in :obj:`header` is 'gzip'.
+
+.. note::
+
+    The :obj:`index_order` parameter must be consistent with the parameter of the same name used in :meth:`read`. Specifying an image to be in 'C' order when reading and than writing it as an 'F' order image will cause the image data to be transposed in the written NRRD file.

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -214,7 +214,7 @@ Writing NRRD files will by default index the :obj:`data` array in Fortran-order 
 
 Index Ordering
 --------------
-NRRD stores the image elements in [row-major ordering](https://en.wikipedia.org/wiki/Row-_and_column-major_order) where the row can be seen as the fastest-varying axis. The header fields of NRRD that describes the axes are always specified in the order from fastest-varying to slowest-varying, i.e., `sizes` will be equal to `(#rows, #columns)`. This is also applicable to images of higher dimensions.
+NRRD stores the image elements in [row-major ordering](https://en.wikipedia.org/wiki/Row-_and_column-major_order) where the row can be seen as the fastest-varying axis. The header fields of NRRD that describes the axes are always specified in the order from fastest-varying to slowest-varying, i.e., `sizes` will be equal to `(# rows, # columns)`. This is also applicable to images of higher dimensions.
 
 Both the reading and writing functions in pynrrd include an :obj:`index_order` parameter that is used to specify whether the returned data array should be in C-order ('C') or Fortran-order ('F').
 

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -182,7 +182,7 @@ Reading NRRD files
 ------------------
 There are three functions that are used to read NRRD files: :meth:`read`, :meth:`read_header` and :meth:`read_data`. :meth:`read` is a convenience function that opens the file located at :obj:`filename` and calls :meth:`read_header` and :meth:`read_data` in succession and returns the data and header.
 
-Reading NRRD files using :meth:`read` or :meth:`read_data` will by default return arrays being indexed in Fortran order, i.e array elements are accessed by `data[x,y,z]`. This differs to the C-order, i.e. `data[z,y,x]`, which is more common in numpy. The :obj:`index_order` parameter can be used to specify which index ordering should be used on the returned array ('C' or 'F'). The :obj:`index_order` parameter needs to be consistent with the parameter of same name in :meth:`write`.
+Reading NRRD files using :meth:`read` or :meth:`read_data` will by default return arrays being indexed in Fortran-order, i.e array elements are accessed by `data[x, y, z]`. This differs from the C-order where array elements are accessed by `data[z, y, x]`, which is the more common order in Python and libraries (e.g. NumPy, scikit-image, PIL, OpenCV). The :obj:`index_order` parameter can be used to specify which index ordering should be used on the returned array ('C' or 'F'). The :obj:`index_order` parameter needs to be consistent with the parameter of same name in :meth:`write`.
 
 The :meth:`read` and :meth:`read_header` methods accept an optional parameter :obj:`custom_field_map` for parsing custom field types not listed in `Supported Fields`_ of the header. It is a :class:`dict` where the key is the custom field name and the value is a string identifying datatype for the custom field. See `Header datatypes`_ for a list of supported datatypes.
 
@@ -196,7 +196,9 @@ Writing NRRD files
 ------------------
 Writing to NRRD files can be done with the single function :meth:`write`. The :obj:`filename` parameter to the function specifies the absolute or relative filename to write the NRRD file. If the :obj:`filename` extension is .nhdr, then the :obj:`detached_header` parameter is set to true automatically. If the :obj:`detached_header` parameter is set to :obj:`True` and the :obj:`filename` ends in .nrrd, then the header file will have the same path and base name as the :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.
 
-The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:`header` is an optional parameter of type :class:`dict` containing the field/values to be saved to the NRRD file. :obj:`index_order` specifies the index order of the array :obj:`data`, this should be consistent with the argument of the same name in :meth:`read`.
+The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:`header` is an optional parameter of type :class:`dict` containing the field/values to be saved to the NRRD file.
+
+Writing NRRD files will by default index the :obj:`data` array in Fortran-order where array elements are accessed by `data[x, y, z]`. This differs from C-order where array elements are accessed by `data[z, y, x]`, which is the more common order in Python and libraries (e.g. NumPy, scikit-image, PIL, OpenCV). The :obj:`index_order` parameter can be used to specify which index ordering should be used for the given :obj:`data` array ('C' or 'F').
 
 .. note::
 
@@ -209,3 +211,59 @@ The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:
 .. note::
 
     The :obj:`index_order` parameter must be consistent with the index order specified in :meth:`read`. Reading an NRRD file in C-order and then writing as Fortran-order or vice versa will result in the data being transposed in the NRRD file.
+
+Index Ordering
+--------------
+NRRD stores the image elements in [row-major ordering](https://en.wikipedia.org/wiki/Row-_and_column-major_order) where the row can be seen as the fastest-varying axis. The header fields of NRRD that describes the axes are always specified in the order from fastest-varying to slowest-varying, i.e., `sizes` will be equal to `(#rows, #columns)`. This is also applicable to images of higher dimensions.
+
+Both the reading and writing functions in pynrrd include an :obj:`index_order` parameter that is used to specify whether the returned data array should be in C-order ('C') or Fortran-order ('F').
+
+Fortran-order is where the dimensions of the multi-dimensional data is ordered from fastest-varying to slowest-varying, i.e. in the same order as the header fields. So for a 3D set of data, the dimensions would be ordered `(x, y, z)`.
+
+On the other hand, C-order is where the dimensions of the multi-dimensional data is ordered from slowest-varying to fastest-varying. So for a 3D set of data, the dimensions would be ordered `(z, y, x)`.
+
+C-order is the index order used in Python and many Python libraries (e.g. NumPy, scikit-image, PIL, OpenCV). pynrrd recommends using C-order indexing to be consistent with the Python community. However, as of this time, the default indexing is Fortran-order to maintain backwards compatibility. In the future, the default index order will be switched to C-order.
+
+.. note::
+
+    Converting from one index order to the other is done via transposing the data.
+
+.. note::
+
+    All header fields are specified in Fortran order, per the NRRD specification, regardless of the index order. For example, a C-ordered array with shape (60, 800, 600) would have a sizes field of (600, 800, 60).
+
+Example reading and writing NRRD files with C-order indexing
+------------------------------------------------------------
+.. code-block:: python
+
+    import numpy as np
+    import nrrd
+
+    # Treat this data array as a 3D volume using C-order indexing
+    # This means we have a volume with a shape of 600x800x70 (x by y by z)
+    data = np.zeros((70, 800, 600))
+    # Save the NRRD object with the correct index order
+    nrrd.write('output.nrrd', data, index_order='C')
+
+    # Read the NRRD file with C-order indexing
+    # Note: We can specify either index order here, this is just a preference unlike in nrrd.write where
+    # it MUST be set based on the data setup
+    data, header = nrrd.read('output.nrrd', index_order='C')
+
+    # The data shape is exactly the same shape as what we wrote
+    print(data.shape)
+    >>> (70, 800, 600)
+
+    # But the shape saved in the header is in Fortran-order
+    print(header['sizes'])
+    >>> [600 800  70]
+
+    # Read the NRRD file with Fortran-order indexing now
+    data, header = nrrd.read('output.nrrd', index_order='F')
+
+    # The data shape is exactly the same shape as what we wrote
+    # The data shape is now in Fortran order, or transposed from what we wrote
+    print(data.shape)
+    >>> (600, 800, 70)
+    print(header['sizes'])
+    >>> [600 800  70]

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -208,4 +208,4 @@ The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:
 
 .. note::
 
-    The :obj:`index_order` parameter must be consistent with the parameter of the same name used in :meth:`read`. Specifying an image to be in 'C' order when reading and than writing it as an 'F' order image will cause the image data to be transposed in the written NRRD file.
+    The :obj:`index_order` parameter must be consistent with the index order specified in :meth:`read`. Reading an NRRD file in C-order and then writing as Fortran-order or vice versa will result in the data being transposed in the NRRD file.

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -318,7 +318,9 @@ def read_data(header, fh=None, filename=None, index_order='F'):
         Filename of the header file. Only necessary if data is detached from the header. This is used to get the
         absolute data path.
     index_order : {'C', 'F'}, optional
-        Specifies the index ordering of the outputted array, either 'F' (Fortran order) or 'C' (C order).
+        Specifies the index order of the resulting data array. Either 'C' (C-order) where the dimensions are ordered from
+        slowest-varying to fastest-varying (e.g. (z, y, x)), or 'F' (Fortran-order) where the dimensions are ordered
+        from fastest-varying to slowest-varying (e.g. (x, y, z)).
 
     Returns
     -------
@@ -455,7 +457,9 @@ def read(filename, custom_field_map=None, index_order='F'):
         Dictionary used for parsing custom field types where the key is the custom field name and the value is a
         string identifying datatype for the custom field.
     index_order : {'C', 'F'}, optional
-        Specifies the index ordering of the outputted array, either 'F' (Fortran order) or 'C' (C order). Using 'F' (default) the image will be transposed, providing an index ordering in this manneri; `data[x][y][z]`. However, Numpy generally uses 'C' order, (e.g. `data[z][y][x]`) and 'C' order is therefore adviced to keep consistent with other libraries. 
+        Specifies the index order of the resulting data array. Either 'C' (C-order) where the dimensions are ordered from
+        slowest-varying to fastest-varying (e.g. (z, y, x)), or 'F' (Fortran-order) where the dimensions are ordered
+        from fastest-varying to slowest-varying (e.g. (x, y, z)).
 
     Returns
     -------

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -444,6 +444,9 @@ def read(filename, custom_field_map=None, index_order='F'):
 
     See :ref:`user-guide:Reading NRRD files` for more information on reading NRRD files.
 
+    .. note::
+            Users should be aware that the `index_order` argument needs to be consistent between `nrrd.read` and `nrrd.write`. I.e., reading an array with `index_order='F'` will result in a transposed version of the original data and hence the writer needs to be aware of this.
+
     Parameters
     ----------
     filename : :class:`str`
@@ -452,7 +455,7 @@ def read(filename, custom_field_map=None, index_order='F'):
         Dictionary used for parsing custom field types where the key is the custom field name and the value is a
         string identifying datatype for the custom field.
     index_order : :class: `str`, optional
-        Specifies the index ordering of the outputted array, either 'F' (Fortran order) or 'C' (C order).
+        Specifies the index ordering of the outputted array, either 'F' (Fortran order) or 'C' (C order). Using 'F' (default) the image will be transposed, providing an index ordering in this manneri; `data[x][y][z]`. However, Numpy generally uses 'C' order, (e.g. `data[z][y][x]`) and 'C' order is therefore adviced to keep consistent with other libraries. 
 
     Returns
     -------

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -454,7 +454,7 @@ def read(filename, custom_field_map=None, index_order='F'):
     custom_field_map : :class:`dict` (:class:`str`, :class:`str`), optional
         Dictionary used for parsing custom field types where the key is the custom field name and the value is a
         string identifying datatype for the custom field.
-    index_order : :class: `str`, optional
+    index_order : {'C', 'F'}, optional
         Specifies the index ordering of the outputted array, either 'F' (Fortran order) or 'C' (C order). Using 'F' (default) the image will be transposed, providing an index ordering in this manneri; `data[x][y][z]`. However, Numpy generally uses 'C' order, (e.g. `data[z][y][x]`) and 'C' order is therefore adviced to keep consistent with other libraries. 
 
     Returns

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -317,7 +317,7 @@ def read_data(header, fh=None, filename=None, index_order='F'):
     filename : :class:`str`, optional
         Filename of the header file. Only necessary if data is detached from the header. This is used to get the
         absolute data path.
-    index_order : :class:`str`, optional
+    index_order : {'C', 'F'}, optional
         Specifies the index ordering of the outputted array, either 'F' (Fortran order) or 'C' (C order).
 
     Returns

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -176,6 +176,9 @@ class TestReadingFunctions(object):
 
         import warnings
         with warnings.catch_warnings(record=True) as w:
+            # Enable all warnings
+            warnings.simplefilter("always")
+
             nrrd.reader.ALLOW_DUPLICATE_FIELD = True
             header = nrrd.read_header(header_txt_tuple)
 

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -8,7 +8,7 @@ from nrrd.tests.util import *
 import nrrd
 
 
-class TestReadingFunctions(unittest.TestCase):
+class TestReadingFunctions(object):
     def setUp(self):
         self.expected_header = {u'dimension': 3,
                                 u'encoding': 'raw',
@@ -20,7 +20,7 @@ class TestReadingFunctions(unittest.TestCase):
                                 u'space origin': np.array([0, 0, 0]),
                                 u'type': 'short'}
 
-        self.expected_data = np.fromfile(RAW_DATA_FILE_PATH, np.int16).reshape((30, 30, 30), order='F')
+        self.expected_data = np.fromfile(RAW_DATA_FILE_PATH, np.int16).reshape((30, 30, 30), order=self.index_order)
 
     def test_read_header_only(self):
         with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
@@ -49,7 +49,7 @@ class TestReadingFunctions(unittest.TestCase):
         np.testing.assert_equal(self.expected_header, header)
 
     def test_read_header_and_data_filename(self):
-        data, header = nrrd.read(RAW_NRRD_FILE_PATH)
+        data, header = nrrd.read(RAW_NRRD_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
@@ -61,7 +61,7 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header = self.expected_header
         expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
 
-        data, header = nrrd.read(RAW_NHDR_FILE_PATH)
+        data, header = nrrd.read(RAW_NHDR_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
@@ -74,7 +74,7 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header[u'data file'] = os.path.basename(RAW_DATA_FILE_PATH)
         expected_header[u'byte skip'] = -1
 
-        data, header = nrrd.read(RAW_BYTESKIP_NHDR_FILE_PATH)
+        data, header = nrrd.read(RAW_BYTESKIP_NHDR_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
@@ -89,7 +89,7 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header[u'encoding'] = 'gzip'
         expected_header[u'data file'] = 'BallBinary30x30x30.nii.gz'
 
-        data, header = nrrd.read(GZ_BYTESKIP_NIFTI_NHDR_FILE_PATH)
+        data, header = nrrd.read(GZ_BYTESKIP_NIFTI_NHDR_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
@@ -100,18 +100,18 @@ class TestReadingFunctions(unittest.TestCase):
     def test_read_detached_header_and_nifti_data(self):
         with self.assertRaisesRegex(nrrd.NRRDError, 'Size of the data does not equal '
                                                     + 'the product of all the dimensions: 27000-27176=-176'):
-            nrrd.read(GZ_NIFTI_NHDR_FILE_PATH)
+            nrrd.read(GZ_NIFTI_NHDR_FILE_PATH, index_order=self.index_order)
 
     def test_read_detached_header_and_data_with_byteskip_minus5(self):
         with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid byteskip, allowed values '
                                                     + 'are greater than or equal to -1'):
-            nrrd.read(RAW_INVALID_BYTESKIP_NHDR_FILE_PATH)
+            nrrd.read(RAW_INVALID_BYTESKIP_NHDR_FILE_PATH, index_order=self.index_order)
 
     def test_read_header_and_gz_compressed_data(self):
         expected_header = self.expected_header
         expected_header[u'encoding'] = 'gzip'
 
-        data, header = nrrd.read(GZ_NRRD_FILE_PATH)
+        data, header = nrrd.read(GZ_NRRD_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
@@ -125,7 +125,7 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header[u'type'] = 'int16'
         expected_header[u'byte skip'] = -1
 
-        data, header = nrrd.read(GZ_BYTESKIP_NRRD_FILE_PATH)
+        data, header = nrrd.read(GZ_BYTESKIP_NRRD_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
@@ -137,7 +137,7 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header = self.expected_header
         expected_header[u'encoding'] = 'bzip2'
 
-        data, header = nrrd.read(BZ2_NRRD_FILE_PATH)
+        data, header = nrrd.read(BZ2_NRRD_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
@@ -150,7 +150,7 @@ class TestReadingFunctions(unittest.TestCase):
         expected_header[u'encoding'] = 'gzip'
         expected_header[u'line skip'] = 3
 
-        data, header = nrrd.read(GZ_LINESKIP_NRRD_FILE_PATH)
+        data, header = nrrd.read(GZ_LINESKIP_NRRD_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(self.expected_header, header)
         np.testing.assert_equal(data, self.expected_data)
@@ -192,7 +192,7 @@ class TestReadingFunctions(unittest.TestCase):
                            u'spacings': [1.0458000000000001],
                            u'type': 'unsigned char'}
 
-        data, header = nrrd.read(ASCII_1D_NRRD_FILE_PATH)
+        data, header = nrrd.read(ASCII_1D_NRRD_FILE_PATH, index_order=self.index_order)
 
         self.assertEqual(header, expected_header)
         np.testing.assert_equal(data.dtype, np.uint8)
@@ -209,11 +209,13 @@ class TestReadingFunctions(unittest.TestCase):
                            u'spacings': [1.0458000000000001, 2],
                            u'type': 'unsigned short'}
 
-        data, header = nrrd.read(ASCII_2D_NRRD_FILE_PATH)
+        data, header = nrrd.read(ASCII_2D_NRRD_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(header, expected_header)
         np.testing.assert_equal(data.dtype, np.uint16)
-        np.testing.assert_equal(data, np.arange(1, 28).reshape(3, 9, order='F'))
+
+        expected_shape = (3, 9) if self.index_order == 'F' else (9, 3)
+        np.testing.assert_equal(data, np.arange(1, 28).reshape(expected_shape, order=self.index_order))
 
         # Test that the data read is able to be edited
         self.assertTrue(data.flags['WRITEABLE'])
@@ -233,7 +235,7 @@ class TestReadingFunctions(unittest.TestCase):
                                                           [0., 1.0000000006, 0.],
                                                           [0., 0., 1.000000000000009]])}
 
-        data, header = nrrd.read(RAW_4D_NRRD_FILE_PATH)
+        data, header = nrrd.read(RAW_4D_NRRD_FILE_PATH, index_order=self.index_order)
 
         np.testing.assert_equal(header, expected_header)
         np.testing.assert_equal(data.dtype, np.float64)
@@ -408,6 +410,12 @@ class TestReadingFunctions(unittest.TestCase):
             with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid endian value in header: "fake"'):
                 nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
+
+class TestWritingFunctionsFortran(TestReadingFunctions, unittest.TestCase):
+    index_order = 'F'
+
+class TestWritingFunctionsC(TestReadingFunctions, unittest.TestCase):
+    index_order = 'C'
 
 if __name__ == '__main__':
     unittest.main()

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -178,9 +178,6 @@ class TestReadingFunctions(object):
 
         import warnings
         with warnings.catch_warnings(record=True) as w:
-            # Enable all warnings
-            warnings.simplefilter("always")
-
             nrrd.reader.ALLOW_DUPLICATE_FIELD = True
             header = nrrd.read_header(header_txt_tuple)
 

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -20,7 +20,9 @@ class TestReadingFunctions(object):
                                 u'space origin': np.array([0, 0, 0]),
                                 u'type': 'short'}
 
-        self.expected_data = np.fromfile(RAW_DATA_FILE_PATH, np.int16).reshape((30, 30, 30), order=self.index_order)
+        self.expected_data = np.fromfile(RAW_DATA_FILE_PATH, np.int16).reshape((30, 30, 30))
+        if self.index_order == 'F':
+            self.expected_data = self.expected_data.T
 
     def test_read_header_only(self):
         with open(RAW_NRRD_FILE_PATH, 'rb') as fh:

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -411,10 +411,10 @@ class TestReadingFunctions(object):
                 nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
 
-class TestWritingFunctionsFortran(TestReadingFunctions, unittest.TestCase):
+class TestReadingFunctionsFortran(TestReadingFunctions, unittest.TestCase):
     index_order = 'F'
 
-class TestWritingFunctionsC(TestReadingFunctions, unittest.TestCase):
+class TestReadingFunctionsC(TestReadingFunctions, unittest.TestCase):
     index_order = 'C'
 
 if __name__ == '__main__':

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -416,6 +416,10 @@ class TestReadingFunctions(object):
                 nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
 
+    def test_invalid_index_order(self):
+        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid index order'):
+            nrrd.read(RAW_NRRD_FILE_PATH, index_order=None)
+
 class TestReadingFunctionsFortran(TestReadingFunctions, unittest.TestCase):
     index_order = 'F'
 

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -9,10 +9,10 @@ from nrrd.tests.util import *
 import nrrd
 
 
-class TestWritingFunctions(unittest.TestCase):
+class TestWritingFunctions(object):
     def setUp(self):
         self.temp_write_dir = tempfile.mkdtemp('nrrdtest')
-        self.data_input, _ = nrrd.read(RAW_NRRD_FILE_PATH)
+        self.data_input, _ = nrrd.read(RAW_NRRD_FILE_PATH, index_order=self.index_order)
 
         with open(RAW_DATA_FILE_PATH, 'rb') as fh:
             self.expected_data = fh.read()
@@ -22,8 +22,8 @@ class TestWritingFunctions(unittest.TestCase):
         nrrd.write(output_filename, self.data_input, {u'encoding': encoding}, compression_level=level)
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(self.expected_data, data.tostring(order=self.index_order))
         self.assertEqual(header['encoding'], encoding)
 
         return output_filename
@@ -33,8 +33,8 @@ class TestWritingFunctions(unittest.TestCase):
         nrrd.write(output_filename, self.data_input)
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(self.expected_data, data.tostring(order=self.index_order))
 
     def test_write_raw(self):
         self.write_and_read_back_with_encoding(u'raw')
@@ -64,36 +64,36 @@ class TestWritingFunctions(unittest.TestCase):
         nrrd.write(output_filename, x, {u'encoding': 'ascii'})
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
         self.assertEqual(header['encoding'], 'ascii')
         np.testing.assert_equal(data, x)
 
     def test_write_ascii_2d(self):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_2d.nrrd')
 
-        x = np.arange(1, 28).reshape(3, 9, order='F')
+        x = np.arange(1, 28).reshape(3, 9, order=self.index_order)
         nrrd.write(output_filename, x, {u'encoding': 'ascii'})
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
         self.assertEqual(header['encoding'], 'ascii')
         np.testing.assert_equal(data, x)
 
     def test_write_ascii_3d(self):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_3d.nrrd')
 
-        x = np.arange(1, 28).reshape(3, 3, 3, order='F')
+        x = np.arange(1, 28).reshape(3, 3, 3, order=self.index_order)
         nrrd.write(output_filename, x, {u'encoding': 'ascii'})
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
         self.assertEqual(header['encoding'], 'ascii')
         np.testing.assert_equal(x, data)
 
     def test_write_custom_fields_without_custom_field_map(self):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_custom_fields.nrrd')
 
-        data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH)
+        data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, index_order=self.index_order)
         nrrd.write(output_filename, data, header)
 
         with open(output_filename, 'r') as fh:
@@ -133,7 +133,7 @@ class TestWritingFunctions(unittest.TestCase):
                             'int matrix': 'int matrix',
                             'double matrix': 'double matrix'}
 
-        data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map)
+        data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map, index_order=self.index_order)
         nrrd.write(output_filename, data, header, custom_field_map=custom_field_map)
 
         with open(output_filename, 'r') as fh:
@@ -168,8 +168,8 @@ class TestWritingFunctions(unittest.TestCase):
                    relative_data_path=False)
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(self.expected_data, data.tostring(order=self.index_order))
         self.assertEqual(header['encoding'], 'raw')
         self.assertEqual(header['data file'], output_data_filename)
 
@@ -179,8 +179,8 @@ class TestWritingFunctions(unittest.TestCase):
         nrrd.write(output_data_filename, self.data_input, {u'encoding': 'raw'}, detached_header=True)
 
         # Read back the same file
-        data, header = nrrd.read(output_data_filename)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        data, header = nrrd.read(output_data_filename, index_order=self.index_order)
+        self.assertEqual(self.expected_data, data.tostring(order=self.index_order))
         self.assertEqual(header['encoding'], 'raw')
         self.assertEqual('data file' in header, False)
 
@@ -198,8 +198,8 @@ class TestWritingFunctions(unittest.TestCase):
         nrrd.write(output_filename, self.data_input, {u'encoding': 'raw'}, detached_header=False)
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(self.expected_data, data.tostring(order=self.index_order))
         self.assertEqual(header['encoding'], 'raw')
         self.assertEqual(header['data file'], 'testfile_detached_raw.raw')
 
@@ -213,8 +213,8 @@ class TestWritingFunctions(unittest.TestCase):
                    relative_data_path=False)
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(self.expected_data, data.tostring(order=self.index_order))
         self.assertEqual(header['encoding'], 'gz')
         self.assertEqual(header['data file'], output_data_filename)
 
@@ -226,8 +226,8 @@ class TestWritingFunctions(unittest.TestCase):
         nrrd.write(output_filename, self.data_input, {u'encoding': 'bz2'}, detached_header=False)
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(self.expected_data, data.tostring(order=self.index_order))
         self.assertEqual(header['encoding'], 'bz2')
         self.assertEqual(header['data file'], 'testfile_detached_raw.raw.bz2')
 
@@ -239,8 +239,8 @@ class TestWritingFunctions(unittest.TestCase):
         nrrd.write(output_filename, self.data_input, {u'encoding': 'txt'}, detached_header=False)
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
-        self.assertEqual(self.expected_data, data.tostring(order='F'))
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(self.expected_data, data.tostring(order=self.index_order))
         self.assertEqual(header['encoding'], 'txt')
         self.assertEqual(header['data file'], 'testfile_detached_raw.txt')
 
@@ -260,7 +260,7 @@ class TestWritingFunctions(unittest.TestCase):
                                         'space dimension': 3})
 
         # Read back the same file
-        data, header = nrrd.read(output_filename)
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
         self.assertEqual(header['encoding'], 'ascii')
 
         # Check for endian and space dimension, both of these should have been removed from the header
@@ -276,6 +276,11 @@ class TestWritingFunctions(unittest.TestCase):
         with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported encoding: "fake"'):
             nrrd.write(output_filename, np.zeros((3, 9)), header)
 
+class TestWritingFunctionsFortran(TestWritingFunctions, unittest.TestCase):
+    index_order = 'F'
+
+class TestWritingFunctionsC(TestWritingFunctions, unittest.TestCase):
+    index_order = 'C'
 
 if __name__ == '__main__':
     unittest.main()

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -282,6 +282,12 @@ class TestWritingFunctions(object):
         with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported encoding: "fake"'):
             nrrd.write(output_filename, np.zeros((3, 9)), header, index_order=self.index_order)
 
+    def test_invalid_index_order(self):
+        output_filename = os.path.join(self.temp_write_dir, 'testfile_invalid_index_order.nrrd')
+
+        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid index order'):
+            nrrd.write(output_filename, np.zeros((3,9)), index_order=None)
+
 class TestWritingFunctionsFortran(TestWritingFunctions, unittest.TestCase):
     index_order = 'F'
 

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -19,7 +19,8 @@ class TestWritingFunctions(object):
 
     def write_and_read_back_with_encoding(self, encoding, level=9):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_{}_{}.nrrd'.format(encoding, str(level)))
-        nrrd.write(output_filename, self.data_input, {u'encoding': encoding}, compression_level=level)
+        nrrd.write(output_filename, self.data_input, {u'encoding': encoding}, compression_level=level,
+                   index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -30,7 +31,7 @@ class TestWritingFunctions(object):
 
     def test_write_default_header(self):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_default_header.nrrd')
-        nrrd.write(output_filename, self.data_input)
+        nrrd.write(output_filename, self.data_input, index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -61,7 +62,7 @@ class TestWritingFunctions(object):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_1d.nrrd')
 
         x = np.arange(1, 28)
-        nrrd.write(output_filename, x, {u'encoding': 'ascii'})
+        nrrd.write(output_filename, x, {u'encoding': 'ascii'}, index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -72,7 +73,7 @@ class TestWritingFunctions(object):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_2d.nrrd')
 
         x = np.arange(1, 28).reshape(3, 9, order=self.index_order)
-        nrrd.write(output_filename, x, {u'encoding': 'ascii'})
+        nrrd.write(output_filename, x, {u'encoding': 'ascii'}, index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -83,7 +84,7 @@ class TestWritingFunctions(object):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_3d.nrrd')
 
         x = np.arange(1, 28).reshape(3, 3, 3, order=self.index_order)
-        nrrd.write(output_filename, x, {u'encoding': 'ascii'})
+        nrrd.write(output_filename, x, {u'encoding': 'ascii'}, index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -94,7 +95,7 @@ class TestWritingFunctions(object):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_custom_fields.nrrd')
 
         data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, index_order=self.index_order)
-        nrrd.write(output_filename, data, header)
+        nrrd.write(output_filename, data, header, index_order=self.index_order)
 
         with open(output_filename, 'r') as fh:
             lines = fh.readlines()
@@ -134,7 +135,7 @@ class TestWritingFunctions(object):
                             'double matrix': 'double matrix'}
 
         data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map, index_order=self.index_order)
-        nrrd.write(output_filename, data, header, custom_field_map=custom_field_map)
+        nrrd.write(output_filename, data, header, custom_field_map=custom_field_map, index_order=self.index_order)
 
         with open(output_filename, 'r') as fh:
             lines = fh.readlines()
@@ -165,7 +166,7 @@ class TestWritingFunctions(object):
         output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nrrd')
 
         nrrd.write(output_data_filename, self.data_input, {u'encoding': 'raw'}, detached_header=True,
-                   relative_data_path=False)
+                   relative_data_path=False, index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -176,7 +177,8 @@ class TestWritingFunctions(object):
     def test_write_detached_raw_odd_extension(self):
         output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nrrd2')
 
-        nrrd.write(output_data_filename, self.data_input, {u'encoding': 'raw'}, detached_header=True)
+        nrrd.write(output_data_filename, self.data_input, {u'encoding': 'raw'}, detached_header=True,
+                   index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_data_filename, index_order=self.index_order)
@@ -188,14 +190,15 @@ class TestWritingFunctions(object):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
 
         with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid encoding specification while writing NRRD file: fake'):
-            nrrd.write(output_filename, self.data_input, {u'encoding': 'fake'})
+            nrrd.write(output_filename, self.data_input, {u'encoding': 'fake'}, index_order=self.index_order)
 
     def test_write_detached_raw(self):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
 
         # Data & header are still detached even though detached_header is False because the filename is .nhdr
         # Test also checks detached data filename that it is relative (default value)
-        nrrd.write(output_filename, self.data_input, {u'encoding': 'raw'}, detached_header=False)
+        nrrd.write(output_filename, self.data_input, {u'encoding': 'raw'}, detached_header=False,
+                   index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -210,7 +213,7 @@ class TestWritingFunctions(object):
         # Data & header are still detached even though detached_header is False because the filename is .nhdr
         # Test also checks detached data filename that it is absolute
         nrrd.write(output_filename, self.data_input, {u'encoding': 'gz'}, detached_header=False,
-                   relative_data_path=False)
+                   relative_data_path=False, index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -223,7 +226,8 @@ class TestWritingFunctions(object):
 
         # Data & header are still detached even though detached_header is False because the filename is .nhdr
         # Test also checks detached data filename that it is relative (default value)
-        nrrd.write(output_filename, self.data_input, {u'encoding': 'bz2'}, detached_header=False)
+        nrrd.write(output_filename, self.data_input, {u'encoding': 'bz2'}, detached_header=False,
+                   index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -236,7 +240,8 @@ class TestWritingFunctions(object):
 
         # Data & header are still detached even though detached_header is False because the filename is .nhdr
         # Test also checks detached data filename that it is relative (default value)
-        nrrd.write(output_filename, self.data_input, {u'encoding': 'txt'}, detached_header=False)
+        nrrd.write(output_filename, self.data_input, {u'encoding': 'txt'}, detached_header=False,
+                   index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -250,14 +255,15 @@ class TestWritingFunctions(object):
         custom_field_map = {'int': 'fake'}
 
         with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid field type given: fake'):
-            nrrd.write(output_filename, np.zeros((3, 9)), header, custom_field_map=custom_field_map)
+            nrrd.write(output_filename, np.zeros((3, 9)), header, custom_field_map=custom_field_map,
+                       index_order=self.index_order)
 
     def test_remove_endianness(self):
         output_filename = os.path.join(self.temp_write_dir, 'testfile_remove_endianness.nrrd')
 
         x = np.arange(1, 28)
         nrrd.write(output_filename, x, {u'encoding': 'ascii', u'endian': 'little', 'space': 'right-anterior-superior',
-                                        'space dimension': 3})
+                                        'space dimension': 3}, index_order=self.index_order)
 
         # Read back the same file
         data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -274,7 +280,7 @@ class TestWritingFunctions(object):
         header = {'encoding': 'fake'}
 
         with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported encoding: "fake"'):
-            nrrd.write(output_filename, np.zeros((3, 9)), header)
+            nrrd.write(output_filename, np.zeros((3, 9)), header, index_order=self.index_order)
 
 class TestWritingFunctionsFortran(TestWritingFunctions, unittest.TestCase):
     index_order = 'F'

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -281,9 +281,12 @@ def _write_data(data, fh, header, compression_level=None, index_order='F'):
         # Write the raw data directly to the file
         fh.write(raw_data)
     elif header['encoding'].lower() in ['ascii', 'text', 'txt']:
-        # Always save ASCII as a single contiguous array to avoid problems with ordering.
-        # Ravel will order the elements depending on the underlying order of the array.
-        np.savetxt(fh, data.ravel(order=index_order), '%.17g')
+        # savetxt only works for 1D and 2D arrays, so reshape any > 2 dim arrays into one long 1D array
+        if data.ndim > 2:
+            np.savetxt(fh, data.ravel(order=index_order), '%.17g')
+        else:
+            np.savetxt(fh, data if index_order == 'C' else data.T, '%.17g')
+
     else:
         # Convert the data into a string
         raw_data = data.tostring(order=index_order)

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -272,6 +272,9 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
 
 
 def _write_data(data, fh, header, compression_level=None, index_order='A'):
+    if index_order not in ['F', 'C', 'A']:
+        raise NRRDError('Invalid index order')
+
     if header['encoding'] == 'raw':
         # Convert the data into a string
         raw_data = data.tostring(order=index_order)

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -94,7 +94,7 @@ def _format_field_value(value, field_type):
 
 
 def write(filename, data, header=None, detached_header=False, relative_data_path=True, custom_field_map=None,
-                          compression_level=9, index_order='A'):
+                          compression_level=9, index_order='F'):
     """Write :class:`numpy.ndarray` to NRRD file
 
     The :obj:`filename` parameter specifies the absolute or relative filename to write the NRRD file to. If the
@@ -135,10 +135,9 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
         - For zlib (.gz): 1-9 set low to high compression; 0 disables; -1 uses zlib default.
         - For bzip2 (.bz2): 1-9 set low to high compression.
     index_order : :class: `str`, optional
-        Specifies the order in which to write the data to file. Could be either 'C', 'F', or 'A'. With 'C' the array
+        Specifies the order in which to write the data to file. Could be either 'C' or 'F'. With 'C' the array
         will be written in C-style order (last axis index changing the fastest) and for 'F' the array will be
-        written in Fortran-style order (first axis index being the fastest). 'A' will use 'C'-order unless the array
-        is flagged as Fortran contiguous in memory, then it will use 'F'-order.
+        written in Fortran-style order (first axis index being the fastest).
 
     See Also
     --------
@@ -169,7 +168,7 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
     # using index_order='C'.
     header['dimension'] = data.ndim
 
-    if (index_order == 'A' and np.isfortran(data)) or index_order == 'F':
+    if index_order == 'F':
         header['sizes'] = list(data.shape)
     else:
         header['sizes'] = list(data.shape[::-1])
@@ -271,8 +270,8 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
             _write_data(data, data_fh, header, compression_level=compression_level, index_order=index_order)
 
 
-def _write_data(data, fh, header, compression_level=None, index_order='A'):
-    if index_order not in ['F', 'C', 'A']:
+def _write_data(data, fh, header, compression_level=None, index_order='F'):
+    if index_order not in ['F', 'C']:
         raise NRRDError('Invalid index order')
 
     if header['encoding'] == 'raw':

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -134,10 +134,12 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
         Int specifying compression level, when using a compressed encoding (.gz, .bz2).
         - For zlib (.gz): 1-9 set low to high compression; 0 disables; -1 uses zlib default.
         - For bzip2 (.bz2): 1-9 set low to high compression.
-    index_order : :class: `str`, optional
+    index_order : {'C', 'F'}, optional
         Specifies the order in which to write the data to file. Could be either 'C' or 'F'. With 'C' the array
         will be written in C-style order (last axis index changing the fastest) and for 'F' the array will be
-        written in Fortran-style order (first axis index being the fastest).
+        Specifies the index order used for writing. Either 'C' (C-order) where the dimensions are ordered from
+        slowest-varying to fastest-varying (e.g. (z, y, x)), or 'F' (Fortran-order) where the dimensions are ordered
+        from fastest-varying to slowest-varying (e.g. (x, y, z)).
 
     See Also
     --------

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -114,6 +114,11 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
     .. note::
             The default encoding field used if not specified in :obj:`header` is 'gzip'.
 
+    .. note::
+            The :obj:`index_order` parameter must be consistent with the index order specified in :meth:`read`.
+            Reading an NRRD file in C-order and then writing as Fortran-order or vice versa will result in the data
+            being transposed in the NRRD file.
+
     See :ref:`user-guide:Writing NRRD files` for more information on writing NRRD files.
 
     Parameters
@@ -135,8 +140,6 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
         - For zlib (.gz): 1-9 set low to high compression; 0 disables; -1 uses zlib default.
         - For bzip2 (.bz2): 1-9 set low to high compression.
     index_order : {'C', 'F'}, optional
-        Specifies the order in which to write the data to file. Could be either 'C' or 'F'. With 'C' the array
-        will be written in C-style order (last axis index changing the fastest) and for 'F' the array will be
         Specifies the index order used for writing. Either 'C' (C-order) where the dimensions are ordered from
         slowest-varying to fastest-varying (e.g. (z, y, x)), or 'F' (Fortran-order) where the dimensions are ordered
         from fastest-varying to slowest-varying (e.g. (x, y, z)).
@@ -169,11 +172,7 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
     # Fortran order we are required to reverse the shape in the case of the array being in C order. E.g., data was read
     # using index_order='C'.
     header['dimension'] = data.ndim
-
-    if index_order == 'F':
-        header['sizes'] = list(data.shape)
-    else:
-        header['sizes'] = list(data.shape[::-1])
+    header['sizes'] = list(data.shape) if index_order == 'F' else list(data.shape[::-1])
 
     # The default encoding is 'gzip'
     if 'encoding' not in header:


### PR DESCRIPTION
This is a proposal for the problem discussed in #75. This should probably be seen as a work-in-progress and a base for further discussion. I'm not sure whether this is the best approach so feedback would be appreciated.

The first addition is the `index_order` argument for `nrrd.read` which allows the user to specify the desired index order. I set the default to 'F' so the behavior should stay the same as with previous versions.

I also changed `nrrd.write`. This function did previously not work on C-contiguous arrays and this should now be fixed. Here I added an `index_order` flag, but my hope is that it should only be required in a few cases. Similar to most numpy functions there are three options; `F`, `C`, and `A`. The `A` (default) option automatically detects the order of the array. So for example, when trying to write an array that was read using `nrrd.read(index_order='F')`, the function should correctly derive the shape and write the array in Fortran order.

At first sight I see only one problem with the `A` option and that is that it breaks down if you do something like this:
```
arr = nrrd.read('in', 'F')
arr = np.ascontiguousarray(arr)
np.write('out', arr)
```
Since `np.ascontiguousarray` will keep the shape but change the underlying memory order, changing it to `C`. This is maybe not something we should worry about though.

Also, to by knowledge there is no way to do parameterized tests using the standard `unittest` module so I did some jury-rigging to test the `index_order` argument. This could probably use some clean-up.