### PR TITLE
Documentation Cleanup

### DIFF
--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -188,11 +188,11 @@ The :meth:`read` and :meth:`read_header` methods accept an optional parameter :o
 
 The :meth:`read_data` will typically be called in conjunction with :meth:`read_header` because header information is required in order to read the data. The function returns a :class:`numpy.ndarray` of the data saved in the given NRRD file.
 
-Some NRRD files, while prohibited by specification, may contain duplicated header fields preventing the proper reading of the file. Changing :data:`nrrd.reader.ALLOW_DUPLICATE_FIELD` to :obj:`True` will show a warning instead of an error while trying to read the file.
+Some NRRD files, while prohibited by specification, may contain duplicated header fields causing an exception to be raised. Changing :data:`nrrd.reader.ALLOW_DUPLICATE_FIELD` to :obj:`True` will show a warning instead of an error while trying to read the file.
 
 Writing NRRD files
 ------------------
-Writing to NRRD files can be done with the single function :meth:`write`. The :obj:`filename` parameter to the function specifies the absolute or relative filename to write the NRRD file. If the :obj:`filename` extension is .nhdr, then the :obj:`detached_header` parameter is set to true automatically. If the :obj:`detached_header` parameter is set to :obj:`True` and the :obj:`filename` ends in .nrrd, then the header file will have the same path and base name as the :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.
+Writing to NRRD files can be done with the function :meth:`write`. The :obj:`filename` parameter to the function specifies the absolute or relative filename to write the NRRD file. If the :obj:`filename` extension is .nhdr, then the :obj:`detached_header` parameter is set to true automatically. If the :obj:`detached_header` parameter is set to :obj:`True` and the :obj:`filename` ends in .nrrd, then the header file will have the same path and base name as the :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.
 
 The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:`header` is an optional parameter of type :class:`dict` containing the field/values to be saved to the NRRD file. 
 

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -103,7 +103,7 @@ int matrix
 :Python Datatype: (M,N) :class:`numpy.ndarray` of :class:`int`
 :Python Example: np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-All rows of the matrix are required, unlike that of the `double matrix`_. If some of the rows need to be 'none', then please use a `double matrix`_ instead. The reason is that empty rows (contain 'none') are represented as a row of NaN's and NaN's are only available for floating point numbers.
+All rows of the matrix are required, unlike that of the `double matrix`_. If some of the rows need to be 'none', then use a `double matrix`_ instead. The reason is that empty rows (i.e. containing 'none') are represented as a row of NaN's, and NaN's are only available for floating point numbers.
 
 double matrix
 ~~~~~~~~~~~~~
@@ -112,10 +112,12 @@ double matrix
 :Python Datatype: (M,N) :class:`numpy.ndarray` of :class:`float`
 :Python Example: np.array([[2.54, 1.3, 0.0], [3.14, 0.3, 3.3], [np.nan, np.nan, np.nan], [0.0, -12.3, -3.3]])
 
-This datatype has the additional feature where certain rows can be defined as empty or none. In the NRRD specification, instead of the row, the 'none' keyword is used in it's place. This is represented in the Python NumPy array as a row of all NaN's (NaN's are only defined for floating point numbers). An example use case for this optional row matrix is for the 'space directions' field where one row may be empty because it is not a domain type. 
+This datatype has the added feature where rows can be defined as empty by setting the vector as :code:`none`. In the NRRD specification, instead of the row, the :code:`none` keyword is used in it's place. This is represented in the Python NumPy array as a row of all NaN's. An example use case for this optional row matrix is for the 'space directions' field where one row may be empty because it is not a domain type.
 
 Supported Fields
 ----------------
+A list of supported fields, according to the NRRD specification, and its corresponding datatype can be seen below. Each field has a link to the NRRD specification providing a detailed description of the field.
+
 ========================  ================
 Field                     NRRD Datatype
 ========================  ================
@@ -180,9 +182,12 @@ space_                    `string`_
 
 Reading NRRD files
 ------------------
-There are three functions that are used to read NRRD files: :meth:`read`, :meth:`read_header` and :meth:`read_data`. :meth:`read` is a convenience function that opens the file located at :obj:`filename` and calls :meth:`read_header` and :meth:`read_data` in succession and returns the data and header.
+There are three functions that are used to read NRRD files: :meth:`read`, :meth:`read_header`, and :meth:`read_data`. :meth:`read` is a convenience function that opens the specified filepath and calls :meth:`read_header` and :meth:`read_data` in succession to return the NRRD header and data.
 
 The :meth:`read` and :meth:`read_header` methods accept an optional parameter :obj:`custom_field_map` for parsing custom field types not listed in `Supported Fields`_ of the header. It is a :class:`dict` where the key is the custom field name and the value is a string identifying datatype for the custom field. See `Header datatypes`_ for a list of supported datatypes.
+
+
+
 
 The :obj:`file` parameter of :meth:`read_header` accepts a filename or a string iterator object to read the header from. If a filename is specified, then the file will be opened and closed after the header is read from it. If not specifying a filename, the :obj:`file` parameter can be any sort of iterator that returns a string each time :meth:`next` is called. The two common objects that meet these requirements are file objects and a list of strings. The :meth:`read_header` function returns a :class:`dict` with the field and parsed values as keys and values to the dictionary.
 

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -16,15 +16,15 @@ The general structure of the NRRD file format is as follows::
     <field>: <value>
     ...
     <field>: <value>
-    <custom field>:= <value>
-    <custom field>:= <value>
+    <custom field>:=<value>
+    <custom field>:=<value>
     ...
-    <custom field>:= <value>
-    # Comments are identified with a pound sign
+    <custom field>:=<value>
+    # Comments are identified with a # symbol
 
     <data here if stored in same file, otherwise stored in detached file>
 
-As with most file formats, the file begins with a magic line that uniquely identifies the file as a NRRD file. Along with the magic line is a version that identifies what revision of the NRRD specification is used. As of today, the latest NRRD version is 5. Line comments can be specified by starting the line with a # symbol. Following the magic line is the header which is written in ASCII with the structure <field>: <value> or <field>:= <value> in the case of a custom field. The header is finished reading once a blank line has been read. If the data is stored in the same file (based on whether the header contains a datafile field), then the data will follow the header.
+As with most file formats, the file begins with a magic line that uniquely identifies the file as a NRRD file. Along with the magic line is a version that identifies what revision of the NRRD specification is used. As of today, the latest NRRD version is 5. Line comments can be specified by starting the line with a # symbol. Following the magic line is the header which is written in ASCII with the structure :code:`<field>: <value>` or :code:`<field>:=<value>` in the case of a custom field. The header is finished reading once a blank line has been read. If the data is stored in the same file (based on whether the header contains a datafile field), then the data will follow the header.
 
 More information on the NRRD file format can be found `here <http://teem.sourceforge.net/nrrd/index.html>`_.
 
@@ -74,9 +74,9 @@ string list
 :Python Datatype: :class:`list` of :class:`str`
 :Python Example: ['this', 'is', 'string', 'separated']
 
-A limitation to the string list is that any strings containing a space in them will be incorrectly separated. In the future, escaping the space could be a useful technique to prevent unwanted separation.
+A limitation to the string list is that any strings containing a space in them will be incorrectly separated. Future work could include handling an escaped space to prevent unwanted separation.
 
-A few fields that are string lists in the NRRD specification are defined with a syntax where there are quotation marks around the strings along with the space delimeter (e.g. "<s>" "<s>" ... "<s>"). The fields that use this style are 'space units', 'units' and 'labels'. The quotation marks seem to be optional but currently they are not handled by the pynrrd library.
+The string list fields 'space units', 'units', and 'labels' are specified to have quotation marks around the strings along with the space delimiter (e.g. "<s>" "<s>" ... "<s>"). At this time, the pynrrd library does not handle quotation marks in string list fields.
 
 int vector
 ~~~~~~~~~~~~~
@@ -85,7 +85,7 @@ int vector
 :Python Datatype: (N,) :class:`numpy.ndarray` of :class:`int`
 :Python Example: np.array([1, 2, 3, 4])
 
-The NRRD specification does not explicitly state that spaces are allowed in the comma delineated vector, such as (1, 2, 3, 4). However, the pynrrd library does correctly parse any vectors that contain spaces after the commas. When saving the NRRD file back, the spaces will be removed from the vector.
+pynrrd will correctly handle vectors with or without spaces between the comma-delimiter. Saving the NRRD file back will remove all spaces between the comma-delimiters.
 
 double vector
 ~~~~~~~~~~~~~
@@ -94,7 +94,7 @@ double vector
 :Python Datatype: (N,) :class:`numpy.ndarray` of :class:`float`
 :Python Example: np.array([1.2, 2.3, 3.4, 4.5])
 
-The NRRD specification does not explicitly state that spaces are allowed in the comma delineated vector, such as (1, 2, 3, 4). However, the pynrrd library does correctly parse any vectors that contain spaces after the commas. When saving the NRRD file back, the spaces will be removed from the vector.
+pynrrd will correctly handle vectors with or without spaces between the comma-delimiter. Saving the NRRD file back will remove all spaces between the comma-delimiters.
 
 int matrix
 ~~~~~~~~~~

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -186,14 +186,9 @@ There are three functions that are used to read NRRD files: :meth:`read`, :meth:
 
 The :meth:`read` and :meth:`read_header` methods accept an optional parameter :obj:`custom_field_map` for parsing custom field types not listed in `Supported Fields`_ of the header. It is a :class:`dict` where the key is the custom field name and the value is a string identifying datatype for the custom field. See `Header datatypes`_ for a list of supported datatypes.
 
+The :meth:`read_data` will typically be called in conjunction with :meth:`read_header` because header information is required in order to read the data. The function returns a :class:`numpy.ndarray` of the data saved in the given NRRD file.
 
-
-
-The :obj:`file` parameter of :meth:`read_header` accepts a filename or a string iterator object to read the header from. If a filename is specified, then the file will be opened and closed after the header is read from it. If not specifying a filename, the :obj:`file` parameter can be any sort of iterator that returns a string each time :meth:`next` is called. The two common objects that meet these requirements are file objects and a list of strings. The :meth:`read_header` function returns a :class:`dict` with the field and parsed values as keys and values to the dictionary.
-
-The :meth:`read_data` will not typically be used besides within the :meth:`read` function because the header is a required parameter (:obj:`header`) to this function. The remaining two parameters :obj:`fh` and :obj:`filename` are optional depending on the parameters but it never hurts to specify both. The file handle (:obj:`fh`) is necessary if the header contains the NRRD data as well (AKA it is not a detached file). However, if the NRRD data is detached from the header, then the :obj:`filename` parameter is required to obtain the absolute path to the data file. The :meth:`read_data` function returns a :class:`numpy.ndarray` of the data.
-
-Some NRRD files, while prohibited by specification, may contain duplicated reader fields preventing the proper reading of the file. Changing :data:`nrrd.reader.ALLOW_DUPLICATE_FIELD` to :obj:`True` will show a warning instead of an error while trying to read the file.
+Some NRRD files, while prohibited by specification, may contain duplicated header fields preventing the proper reading of the file. Changing :data:`nrrd.reader.ALLOW_DUPLICATE_FIELD` to :obj:`True` will show a warning instead of an error while trying to read the file.
 
 Writing NRRD files
 ------------------


### PR DESCRIPTION
Simplify and reword content in the user guide of documentation. Felt there was some confusing and unnecessarily complex sentences. In addition, removed some content that is not relevant for a user interested in just getting started using `pynrrd`.