### PR TITLE
Remove documentation regarding compression_level=0

### DIFF
--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -132,8 +132,8 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
         string identifying datatype for the custom field.
     compression_level : :class:`int`
         Int specifying compression level, when using a compressed encoding (.gz, .bz2).
-        - For zlib (.gz): 1-9 set low to high compression; 0 disables; -1 uses zlib default.
-        - For bzip2 (.bz2): 1-9 set low to high compression.
+        - 1: Fastest and compresses data the least
+        - 9: Slowest and compresses data the most
 
     See Also
     --------

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -131,9 +131,9 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
         Dictionary used for parsing custom field types where the key is the custom field name and the value is a
         string identifying datatype for the custom field.
     compression_level : :class:`int`
-        Int specifying compression level, when using a compressed encoding (.gz, .bz2).
-        - 1: Fastest and compresses data the least
-        - 9: Slowest and compresses data the most
+        Integer between 1 to 9 specifying the compression level when using a compressed encoding (gzip or bzip). A value
+        of :obj:`1` compresses the data the least amount and is the fastest, while a value of :obj:`9` compresses the
+        data the most and is the slowest.
 
     See Also
     --------


### PR DESCRIPTION
The GZIP library supports a compression level of `0` for no compression but this has been found to be slower than setting the encoding to `raw`. This PR removes documentation for setting `compression_level=0`. In addition, `bz2` in Python does not support a compression level of 0. Another benefit of this PR is the unified compression level range.

Note that the user can still specify a compression level of 0 at their own risk.

Fixes issue #88