### PR TITLE
Improve compressed NRRD read performance

### DIFF
--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -397,7 +397,7 @@ def read_data(header, fh=None, filename=None):
             raise NRRDError('Unsupported encoding: "%s"' % header['encoding'])
 
         # Loop through the file and read a chunk at a time (see _READ_CHUNKSIZE why it is read in chunks)
-        decompressed_data = b''
+        decompressed_data = bytearray()
         while True:
             chunk = fh.read(_READ_CHUNKSIZE)
 
@@ -410,7 +410,7 @@ def read_data(header, fh=None, filename=None):
 
         # Byte skip is applied AFTER the decompression. Skip first x bytes of the decompressed data and parse it using
         # NumPy
-        data = np.fromstring(decompressed_data[byte_skip:], dtype)
+        data = np.frombuffer(decompressed_data[byte_skip:], dtype)
 
     # Close the file
     # Even if opened using with keyword, closing it does not hurt

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -8,11 +8,11 @@ from collections import OrderedDict
 
 from nrrd.parsers import *
 
-# Reading and writing gzipped data directly gives problems when the uncompressed
-# data is larger than 4GB (2^32). Therefore we'll read and write the data in
-# chunks. How this affects speed and/or memory usage is something to be analyzed
-# further. The following two values define the size of the chunks.
-_READ_CHUNKSIZE = 2 ** 20
+# Older versions of Python had issues when uncompressed data was larger than 4GB (2^32). This should be fixed in latest
+# version of Python 2.7 and all versions of Python 3. The fix for this issue is to read the data in smaller chunks.
+# Chunk size is set to be large at 1GB to improve performance. If issues arise decompressing larger files, try to reduce
+# this value
+_READ_CHUNKSIZE = 2 ** 32
 
 _NRRD_REQUIRED_FIELDS = ['dimension', 'type', 'encoding', 'sizes']
 
@@ -369,7 +369,7 @@ def read_data(header, fh=None, filename=None):
             fh.readline()
     else:
         raise NRRDError('Invalid lineskip, allowed values are greater than or equal to 0')
-        
+
     # Skip the requested number of bytes or seek backward, and then parse the data using NumPy
     if byte_skip < -1:
         raise NRRDError('Invalid byteskip, allowed values are greater than or equal to -1')
@@ -380,9 +380,9 @@ def read_data(header, fh=None, filename=None):
     else:
         # The only case left should be: byte_skip == -1 and header['encoding'] == 'gzip'
         byte_skip = -dtype.itemsize * total_data_points
-        
+
     # If a compression encoding is used, then byte skip AFTER decompressing
-    if header['encoding'] == 'raw':             
+    if header['encoding'] == 'raw':
         data = np.fromfile(fh, dtype)
     elif header['encoding'] in ['ASCII', 'ascii', 'text', 'txt']:
         data = np.fromfile(fh, dtype, sep=' ')
@@ -398,15 +398,28 @@ def read_data(header, fh=None, filename=None):
 
         # Loop through the file and read a chunk at a time (see _READ_CHUNKSIZE why it is read in chunks)
         decompressed_data = bytearray()
-        while True:
-            chunk = fh.read(_READ_CHUNKSIZE)
 
-            # If chunk is None, then file is at end, break out of loop
-            if not chunk:
-                break
+        # Read all of the remaining data from the file
+        # Obtain the length of the compressed data since we will be using it repeatedly, more efficient
+        compressed_data = fh.read()
+        compressed_data_len = len(compressed_data)
+        start_index = 0
 
-            # Decompress the data and add it to the decompressed data
-            decompressed_data += decompobj.decompress(chunk)
+        # Loop through data and decompress it chunk by chunk
+        while start_index < compressed_data_len:
+            # Calculate the end index = start index plus chunk size
+            # Set to the string length to read the remaining chunk at the end
+            end_index = min(start_index + _READ_CHUNKSIZE, compressed_data_len)
+
+            # Decompress and append data
+            decompressed_data += decompobj.decompress(compressed_data[start_index:end_index])
+
+            # Update start index
+            start_index = end_index
+
+        # Delete the compressed data since we do not need it anymore
+        # This could potentially be using a lot of memory
+        del compressed_data
 
         # Byte skip is applied AFTER the decompression. Skip first x bytes of the decompressed data and parse it using
         # NumPy

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -8,10 +8,10 @@ from nrrd.errors import NRRDError
 from nrrd.formatters import *
 from nrrd.reader import _get_field_type
 
-# Reading and writing gzipped data directly gives problems when the uncompressed
-# data is larger than 4GB (2^32). Therefore we'll read and write the data in
-# chunks. How this affects speed and/or memory usage is something to be analyzed
-# further. The following two values define the size of the chunks.
+# Older versions of Python had issues when uncompressed data was larger than 4GB (2^32). This should be fixed in latest
+# version of Python 2.7 and all versions of Python 3. The fix for this issue is to read the data in smaller chunks. The
+# chunk size is set to be small here at 1MB since performance did not vary much based on the chunk size. A smaller chunk
+# size has the benefit of using less RAM at once.
 _WRITE_CHUNKSIZE = 2 ** 20
 
 _NRRD_FIELD_ORDER = [
@@ -67,6 +67,7 @@ _NUMPY2NRRD_ENDIAN_MAP = {
     'B': 'big'
 }
 
+
 def _format_field_value(value, field_type):
     if field_type == 'int':
         return format_number(value)
@@ -94,7 +95,7 @@ def _format_field_value(value, field_type):
 
 
 def write(filename, data, header=None, detached_header=False, relative_data_path=True, custom_field_map=None,
-                          compression_level=9):
+          compression_level=9):
     """Write :class:`numpy.ndarray` to NRRD file
 
     The :obj:`filename` parameter specifies the absolute or relative filename to write the NRRD file to. If the
@@ -286,16 +287,15 @@ def _write_data(data, fh, header, compression_level=None):
             raise NRRDError('Unsupported encoding: "%s"' % header['encoding'])
 
         # Write the data in chunks (see _WRITE_CHUNKSIZE declaration for more information why)
+        # Obtain the length of the data since we will be using it repeatedly, more efficient
         start_index = 0
+        raw_data_len = len(raw_data)
 
         # Loop through the data and write it by chunk
-        while start_index < len(raw_data):
+        while start_index < raw_data_len:
             # End index is start index plus the chunk size
-            end_index = start_index + _WRITE_CHUNKSIZE
-
-            # If the end index is past the data size, then clamp it to the data size
-            if end_index > len(raw_data):
-                end_index = len(raw_data)
+            # Set to the string length to read the remaining chunk at the end
+            end_index = min(start_index + _WRITE_CHUNKSIZE, raw_data_len)
 
             # Write the compressed data
             fh.write(compressobj.compress(raw_data[start_index:end_index]))


### PR DESCRIPTION
This PR makes two changes to improve the performance of the `nrrd.write` function for compressed NRRD files, i.e. gzip or bzip2 compressed data.

The first change is to switch the decompressed data buffer from a `bytes` object to a `bytearray`. A `bytes` object is immutable and so appending to a `bytes` object requires that a new object is created in memory with the data. `bytearray` is a mutable object similar to `bytes` except that appending to the `bytearray` will result in adding the data to the array and allocating memory **only** if necessary. In addition, importing the data into a Numpy array is switched from `np.fromstring` to `np.frombuffer`. This is done because we no longer have a string **and** because there is a warning about `np.fromstring` being deprecated. Performance tests (see the issue for more details) show a large speedup with this improvement.

The second change fine tunes the chunk size parameter and how it is used in `nrrd.read`. Previously, the chunk size was set to 1MB and it would read a 1MB chunk and then decompress it. For larger files, this is inefficient. This PR changes the chunk size to be 1GB and also changes it such that the entire compressed data is read all at once and then only the decompression is chunked. The reasoning is detailed below...

Based on an initial analysis, it was found that increasing the chunk size for `nrrd.write` actually increased the amount of time required to write the file. The exact difference may vary depending on the machine but the general trend should be consistent. With that, the write chunk size was kept at 1MB to preserve RAM while writing. The example experiment uses random data to be written which likely affects the compression ratio, but additional tests were done with non-random data and similar results were achieved as described.

Experiment for writing large amounts of data with various chunk sizes:
https://gist.github.com/addisonElliott/097de1ca1311026e2e116541c9eed0c5#file-write_experiment-py

Changing the `nrrd.read` chunk size alone does not improve performance. Upon analysis, it was found that there was a large delay for small & large files with a large chunk size when calling `fh.read(CHUNK_SIZE)`. For example, a 3kB file took 0.7s to return with a 1GB chunk size while it takes 100s of microseconds when using a 1MB chunk size. In the experiment linked below, it is shown that there is a speedup for large files but smaller files had almost a 50% slow down in performance.

Experiment for reading small/large files with various chunk sizes:
https://gist.github.com/addisonElliott/097de1ca1311026e2e116541c9eed0c5#file-read_normal_experiment-py

As mentioned above, the resolution to the slow down with a larger chunk size on smaller files is to read the entire file into memory at once using `fh.read()` (no argument). This has the disadvantage of using additional memory but the fact of the matter is that reading a raw-encoded NRRD file loads the entire file into memory. In addition, the data will need to be in memory anyway when it is converted to a Numpy array. Even furthermore, we are reading the decompressed data, so the user should have enough RAM if they are expecting to be able to hold the uncompressed data in RAM.

With the entire compressed file read in at once now, the chunk size is set to be 1GB to increase performance on reading larger files while keeping the same performance for smaller files. The chunk size only sets the amount of data to decompress at once.

One potential concern with a larger chunk size is that there is an issue in older versions of Python where zlib is unable to decompress data that is larger than 4GB in file size. See issue #21 for more details. However, as far as I can tell this is fixed in the latest version of Python 2.7 and all versions of Python 3. See source [here](https://stackoverflow.com/questions/30376224/python-gzip-overflowerror-size-does-not-fit-in-an-int) and [here](https://bugs.python.org/issue23306) for more information. Note that these fixes came out after the `pynrrd` issue was reported.

The fixed benchmark can be seen here:
https://gist.github.com/addisonElliott/097de1ca1311026e2e116541c9eed0c5#file-read_fixed_experiment-py

Note that performance is similar for small files and for the 1GB file with a 1GB chunk size, the performance is increased by ~15%.

Fixes issue #88