### PR TITLE
Remove tests from setuptools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,14 @@ or, for the last line, instead use:
 to install in 'develop' or 'editable' mode, where changes can be made to the local working code and Python will use
 the updated pynrrd code.
 
+**Tests**
+
+The tests can be run via the following command from the base directory:
+
+.. code-block:: bash
+
+    python -m unittest discover -v nrrd/tests
+
 Example usage
 -------------
 .. code-block:: python
@@ -86,13 +94,6 @@ Example usage
     print(header)
 
 
-Tests
------
-Run the following command in the base directory to run the tests:
-
-.. code-block:: bash
-
-    python -m unittest discover -v nrrd/tests
 
 Next Steps
 ----------

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='pynrrd',
       url='https://github.com/mhe/pynrrd',
       license='MIT License',
       install_requires=['numpy>=1.11.1'],
-      packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+      packages=find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']),
       keywords='nrrd teem image processing file format',
       classifiers=[
           'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name='pynrrd',
       url='https://github.com/mhe/pynrrd',
       license='MIT License',
       install_requires=['numpy>=1.11.1'],
-      packages=find_packages(),
+      packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
       keywords='nrrd teem image processing file format',
       classifiers=[
           'License :: OSI Approved :: MIT License',

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,6 @@ setup(name='pynrrd',
       license='MIT License',
       install_requires=['numpy>=1.11.1'],
       packages=find_packages(),
-      package_data={
-          'nrrd': ['tests/*']
-      },
       keywords='nrrd teem image processing file format',
       classifiers=[
           'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Remove tests from packaged distributions. Most users won't need to run the tests when they install `pynrrd`, so it is unnecessary files to pass along. In addition, the data was missing in order for the tests to run successfully.

Fixes #84 