### PR TITLE
Fix issue with loading large files

### DIFF
--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -367,7 +367,7 @@ def read_data(header, fh=None, filename=None, index_order='F'):
         fh = open(data_filename, 'rb')
 
     # Get the total number of data points by multiplying the size of each dimension together
-    total_data_points = header['sizes'].prod()
+    total_data_points = header['sizes'].prod(dtype=np.int64)
 
     # Skip the number of lines requested when line_skip >= 0
     # Irrespective of the NRRD file having attached/detached header

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -412,16 +412,18 @@ class TestReadingFunctions(object):
             with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid endian value in header: "fake"'):
                 nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
-
     def test_invalid_index_order(self):
         with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid index order'):
             nrrd.read(RAW_NRRD_FILE_PATH, index_order=None)
 
+
 class TestReadingFunctionsFortran(TestReadingFunctions, unittest.TestCase):
     index_order = 'F'
 
+
 class TestReadingFunctionsC(TestReadingFunctions, unittest.TestCase):
     index_order = 'C'
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is the error message that would popup before this fix:

```
Size of the data does not equal to the product of all dimensions
```

Problem was that multiplying the dimensions together was overflowing the 32-bit result for larger than 4GB files.

Fixes #100