### PR TITLE
Account for 'data file' and 'datafile' in header when writing NRRD file

### DIFF
--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -310,6 +310,26 @@ class TestWritingFunctions(object):
             self.assertTrue('space units: "mm" "cm" "in"' in lines)
             self.assertTrue('labels: "X" "Y" "f(log(X, 10), Y)"' in lines)
 
+    def test_write_detached_datafile_check(self):
+        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
+
+        nrrd.write(output_filename, self.data_input, {'datafile': 'testfile_detached.gz'}, detached_header=True,
+                   index_order=self.index_order)
+
+        # Read back the same file
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(header['data file'], 'testfile_detached.raw.gz')
+
+    def test_write_detached_datafile_check2(self):
+        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
+
+        nrrd.write(output_filename, self.data_input, {'data file': 'testfile_detached.gz'}, detached_header=True,
+                   index_order=self.index_order)
+
+        # Read back the same file
+        data, header = nrrd.read(output_filename, index_order=self.index_order)
+        self.assertEqual(header['data file'], 'testfile_detached.raw.gz')
+
 
 class TestWritingFunctionsFortran(TestWritingFunctions, unittest.TestCase):
     index_order = 'F'

--- a/nrrd/writer.py
+++ b/nrrd/writer.py
@@ -180,6 +180,11 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
     if 'encoding' not in header:
         header['encoding'] = 'gzip'
 
+    # If 'datafile' is specified, then we rename to 'data file'
+    # The standard seems to advocate for 'data file' OVER 'datafile'
+    if 'datafile' in header:
+        header['data file'] = header.pop('datafile')
+
     # A bit of magic in handling options here.
     # If *.nhdr filename provided, this overrides `detached_header=False`
     # If *.nrrd filename provided AND detached_header=True, separate header and data files written.
@@ -188,7 +193,9 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
     if filename.endswith('.nhdr'):
         detached_header = True
 
-        if 'data file' not in header:
+        # TODO This will cause issues for relative data files because it will not save in the correct spot
+        data_filename = header.get('datafile', None)
+        if not data_filename:
             # Get the base filename without the extension
             base_filename = os.path.splitext(filename)[0]
 
@@ -207,9 +214,6 @@ def write(filename, data, header=None, detached_header=False, relative_data_path
 
             header['data file'] = os.path.basename(data_filename) \
                 if relative_data_path else os.path.abspath(data_filename)
-        else:
-            # TODO This will cause issues for relative data files because it will not save in the correct spot
-            data_filename = header['data file']
     elif filename.endswith('.nrrd') and detached_header:
         data_filename = filename
         header['data file'] = os.path.basename(data_filename) \


### PR DESCRIPTION
Standardizes the output by replacing 'datafile' with 'data file'.

The NRRD spec seems to advocate for 'data file' over 'datafile'. There is a minor footnote mentioning that 'datafile' is allowed and 'data file' is used throughout their documentation.

Fixes #97