### PR TITLE
Update docs wording & example

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -9,10 +9,10 @@ Basic Example
 
     import numpy as np
     import nrrd
-    
+
     data = np.linspace(1, 50, 50)
     nrrd.write('output.nrrd', data)
-    
+
     data2, header = nrrd.read('output.nrrd')
     print(np.all(data == data2))
     >>> True
@@ -26,10 +26,10 @@ Example only reading header
 
     import numpy as np
     import nrrd
-    
+
     data = np.linspace(1, 50, 50)
     nrrd.write('output.nrrd', data)
-    
+
     header = nrrd.read_header('output.nrrd')
     print(header)
     >>> OrderedDict([('type', 'double'), ('dimension', 1), ('sizes', array([50])), ('endian', 'little'), ('encoding', 'gzip')])
@@ -54,7 +54,7 @@ Example write and read from memory
     print(header)
     >>> OrderedDict([('type', 'double'), ('dimension', 1), ('sizes', array([50])), ('endian', 'little'), ('encoding', 'gzip')])
 
-    data2 = nrrd.read_data(header=header, fh=memory_nrrd)
+    data2 = nrrd.read_data(header, memory_nrrd)
 
     print(np.all(data == data2))
     >>> True
@@ -69,19 +69,19 @@ Example with fields and custom fields
     data = np.linspace(1, 60, 60).reshape((3, 10, 2))
     header = {'kinds': ['domain', 'domain', 'domain'], 'units': ['mm', 'mm', 'mm'], 'spacings': [1.0458, 1.0458, 2.5], 'space': 'right-anterior-superior', 'space directions': np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), 'encoding': 'ASCII', 'custom_field_here1': 24.34, 'custom_field_here2': np.array([1, 2, 3, 4])}
     custom_field_map = {'custom_field_here1': 'double', 'custom_field_here2': 'int list'}
-    
+
     nrrd.write('output.nrrd', data, header, custom_field_map=custom_field_map)
-    
+
     data2, header2 = nrrd.read('output.nrrd', custom_field_map)
-    
+
     print(np.all(data == data2))
     >>> True
-    
+
     print(header)
     >>> {'units': ['mm', 'mm', 'mm'], 'spacings': [1.0458, 1.0458, 2.5], 'custom_field_here1': 24.34, 'space': 'right-anterior-superior', 'space directions': array([[1, 0, 0],
        [0, 1, 0],
        [0, 0, 1]]), 'type': 'double', 'encoding': 'ASCII', 'kinds': ['domain', 'domain', 'domain'], 'dimension': 3, 'custom_field_here2': array([1, 2, 3, 4]), 'sizes': [3, 10, 2]}
-    
+
     print(header2)
     >>> OrderedDict([('type', 'double'), ('dimension', 3), ('space', 'right-anterior-superior'), ('sizes', array([ 3, 10,  2])), ('space directions', array([[1., 0., 0.],
        [0., 1., 0.],

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -197,7 +197,7 @@ Some NRRD files, while prohibited by specification, may contain duplicated heade
 
 Writing NRRD files
 ------------------
-Writing to NRRD files can be done with the function :meth:`write`. The :obj:`filename` parameter to the function specifies the absolute or relative filename to write the NRRD file. If the :obj:`filename` extension is .nhdr, then the :obj:`detached_header` parameter is set to true automatically. If the :obj:`detached_header` parameter is set to :obj:`True` and the :obj:`filename` ends in .nrrd, then the header file will have the same path and base name as the :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.
+Writing to NRRD files can be done with the function :meth:`write`. The :obj:`filename` parameter to the function specifies the absolute or relative filename to write the NRRD file. If the :obj:`filename` extension is .nhdr, then :obj:`detached_header` will be set to true automatically. If :obj:`detached_header` is :obj:`True` and :obj:`filename` extension is .nrrd, then the header file will have the same path and base name as :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.
 
 The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:`header` is an optional parameter of type :class:`dict` containing the field/values to be saved to the NRRD file.
 

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -197,7 +197,7 @@ Some NRRD files, while prohibited by specification, may contain duplicated heade
 
 Writing NRRD files
 ------------------
-Writing to NRRD files can be done with the function :meth:`write`. The :obj:`filename` parameter to the function specifies the absolute or relative filename to write the NRRD file. If the :obj:`filename` extension is .nhdr, then :obj:`detached_header` will be set to true automatically. If :obj:`detached_header` is :obj:`True` and :obj:`filename` extension is .nrrd, then the header file will have the same path and base name as :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.
+Writing to NRRD files can be done with the function :meth:`write`. The :obj:`filename` parameter specifies either an absolute or relative filename to write the NRRD file to. If the :obj:`filename` extension is .nhdr, then :obj:`detached_header` will be set to true automatically. If :obj:`detached_header` is :obj:`True` and :obj:`filename` extension is .nrrd, then the header file will have the same path and base name as :obj:`filename` but with an extension of .nhdr. In all other cases, the header and data are saved in the same file.
 
 The :obj:`data` parameter is a :class:`numpy.ndarray` of data to be saved. :obj:`header` is an optional parameter of type :class:`dict` containing the field/values to be saved to the NRRD file.
 

--- a/docs/source/user-guide.rst
+++ b/docs/source/user-guide.rst
@@ -72,7 +72,7 @@ string list
 :NRRD Syntax: <s> <s> ... <s>
 :NRRD Example: this is space separated
 :Python Datatype: :class:`list` of :class:`str`
-:Python Example: ['this', 'is', 'string', 'separated']
+:Python Example: ['this', 'is', 'space', 'separated']
 
 quoted string list
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Remove named argument usage for NRRD in examples docs. For `fh` and `header`, these should not be named since they are primary (i.e. not optional) arguments.

Update wording on docs for user-guide section.