### PR TITLE
Remove polyfill for assertRaisesRegex function in unittest module

### DIFF
--- a/nrrd/tests/test_formatting.py
+++ b/nrrd/tests/test_formatting.py
@@ -1,7 +1,7 @@
 import numpy as np
+import unittest
 
 import nrrd
-from nrrd.tests.util import *
 
 
 class TestFieldFormatting(unittest.TestCase):

--- a/nrrd/tests/test_formatting.py
+++ b/nrrd/tests/test_formatting.py
@@ -1,5 +1,6 @@
-import numpy as np
 import unittest
+
+import numpy as np
 
 import nrrd
 

--- a/nrrd/tests/test_parsing.py
+++ b/nrrd/tests/test_parsing.py
@@ -1,5 +1,6 @@
-import numpy as np
 import unittest
+
+import numpy as np
 
 import nrrd
 

--- a/nrrd/tests/test_parsing.py
+++ b/nrrd/tests/test_parsing.py
@@ -1,7 +1,7 @@
 import numpy as np
+import unittest
 
 import nrrd
-from nrrd.tests.util import *
 
 
 class TestFieldParsing(unittest.TestCase):

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -1,5 +1,6 @@
-import numpy as np
 import unittest
+
+import numpy as np
 
 import nrrd
 from nrrd.tests.util import *

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -1,4 +1,5 @@
 import numpy as np
+import unittest
 
 import nrrd
 from nrrd.tests.util import *

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -1,6 +1,7 @@
 import io
 import tempfile
 import unittest
+
 import numpy as np
 
 import nrrd

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -1,6 +1,6 @@
 import io
 import tempfile
-
+import unittest
 import numpy as np
 
 import nrrd

--- a/nrrd/tests/util.py
+++ b/nrrd/tests/util.py
@@ -22,8 +22,3 @@ RAW_4D_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'test_simple4d_raw.nrrd')
 ASCII_1D_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'test1d_ascii.nrrd')
 ASCII_2D_NRRD_FILE_PATH = os.path.join(DATA_DIR_PATH, 'test2d_ascii.nrrd')
 ASCII_1D_CUSTOM_FIELDS_FILE_PATH = os.path.join(DATA_DIR_PATH, 'test_customFields.nrrd')
-
-# Fix issue with assertRaisesRegex only available in Python 3 while
-# assertRaisesRegexp is available in Python 2 (and deprecated in Python 3)
-if not hasattr(unittest.TestCase, 'assertRaisesRegex'):
-    unittest.TestCase.assertRaisesRegex = getattr(unittest.TestCase, 'assertRaisesRegexp')

--- a/nrrd/tests/util.py
+++ b/nrrd/tests/util.py
@@ -1,5 +1,4 @@
 import os
-import unittest
 import warnings
 
 # Enable all warnings


### PR DESCRIPTION
No longer needed since Python 2 support has been dropped
