### PR TITLE
Minor tweaking to read & write tests

### DIFF
--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import ClassVar, Literal
 
 import numpy as np
 
@@ -8,6 +9,8 @@ from nrrd.tests.util import *
 
 class Abstract:
     class TestReadingFunctions(unittest.TestCase):
+        index_order: ClassVar[Literal['F', 'C']]
+
         def setUp(self):
             self.expected_header = {'dimension': 3,
                                     'encoding': 'raw',

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -6,461 +6,462 @@ import nrrd
 from nrrd.tests.util import *
 
 
-class TestReadingFunctions:
-    def setUp(self):
-        self.expected_header = {'dimension': 3,
-                                'encoding': 'raw',
-                                'endian': 'little',
-                                'kinds': ['domain', 'domain', 'domain'],
-                                'sizes': np.array([30, 30, 30]),
-                                'space': 'left-posterior-superior',
-                                'space directions': np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                                'space origin': np.array([0, 0, 0]),
-                                'type': 'short'}
+class Abstract:
+    class TestReadingFunctions(unittest.TestCase):
+        def setUp(self):
+            self.expected_header = {'dimension': 3,
+                                    'encoding': 'raw',
+                                    'endian': 'little',
+                                    'kinds': ['domain', 'domain', 'domain'],
+                                    'sizes': np.array([30, 30, 30]),
+                                    'space': 'left-posterior-superior',
+                                    'space directions': np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+                                    'space origin': np.array([0, 0, 0]),
+                                    'type': 'short'}
 
-        self.expected_data = np.fromfile(RAW_DATA_FILE_PATH, np.int16).reshape((30, 30, 30))
-        if self.index_order == 'F':
-            self.expected_data = self.expected_data.T
+            self.expected_data = np.fromfile(RAW_DATA_FILE_PATH, np.int16).reshape((30, 30, 30))
+            if self.index_order == 'F':
+                self.expected_data = self.expected_data.T
 
-    def test_read_header_only(self):
-        with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
+        def test_read_header_only(self):
+            with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
 
-        # np.testing.assert_equal is used to compare the headers because it will appropriately handle each
-        # value in the structure. Since some of the values can be Numpy arrays inside the headers, this must be
-        # used to compare the two values.
-        np.testing.assert_equal(self.expected_header, header)
+            # np.testing.assert_equal is used to compare the headers because it will appropriately handle each
+            # value in the structure. Since some of the values can be Numpy arrays inside the headers, this must be
+            # used to compare the two values.
+            np.testing.assert_equal(self.expected_header, header)
 
-    def test_read_header_only_with_filename(self):
-        header = nrrd.read_header(RAW_NRRD_FILE_PATH)
+        def test_read_header_only_with_filename(self):
+            header = nrrd.read_header(RAW_NRRD_FILE_PATH)
 
-        # np.testing.assert_equal is used to compare the headers because it will appropriately handle each
-        # value in the structure. Since some of the values can be Numpy arrays inside the headers, this must be
-        # used to compare the two values.
-        np.testing.assert_equal(self.expected_header, header)
+            # np.testing.assert_equal is used to compare the headers because it will appropriately handle each
+            # value in the structure. Since some of the values can be Numpy arrays inside the headers, this must be
+            # used to compare the two values.
+            np.testing.assert_equal(self.expected_header, header)
 
-    def test_read_detached_header_only(self):
-        expected_header = self.expected_header
-        expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
+        def test_read_detached_header_only(self):
+            expected_header = self.expected_header
+            expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
 
-        with open(RAW_NHDR_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
+            with open(RAW_NHDR_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
 
-        np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(self.expected_header, header)
 
-    def test_read_header_and_data_filename(self):
-        data, header = nrrd.read(RAW_NRRD_FILE_PATH, index_order=self.index_order)
+        def test_read_header_and_data_filename(self):
+            data, header = nrrd.read(RAW_NRRD_FILE_PATH, index_order=self.index_order)
 
-        np.testing.assert_equal(self.expected_header, header)
-        np.testing.assert_equal(data, self.expected_data)
+            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(data, self.expected_data)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_read_detached_header_and_data(self):
-        expected_header = self.expected_header
-        expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
+        def test_read_detached_header_and_data(self):
+            expected_header = self.expected_header
+            expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
 
-        data, header = nrrd.read(RAW_NHDR_FILE_PATH, index_order=self.index_order)
+            data, header = nrrd.read(RAW_NHDR_FILE_PATH, index_order=self.index_order)
 
-        np.testing.assert_equal(self.expected_header, header)
-        np.testing.assert_equal(data, self.expected_data)
+            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(data, self.expected_data)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_read_detached_header_and_data_with_byteskip_minus1(self):
-        expected_header = self.expected_header
-        expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
-        expected_header['byte skip'] = -1
+        def test_read_detached_header_and_data_with_byteskip_minus1(self):
+            expected_header = self.expected_header
+            expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
+            expected_header['byte skip'] = -1
 
-        data, header = nrrd.read(RAW_BYTESKIP_NHDR_FILE_PATH, index_order=self.index_order)
+            data, header = nrrd.read(RAW_BYTESKIP_NHDR_FILE_PATH, index_order=self.index_order)
 
-        np.testing.assert_equal(self.expected_header, header)
-        np.testing.assert_equal(data, self.expected_data)
+            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(data, self.expected_data)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_read_detached_header_and_nifti_data_with_byteskip_minus1(self):
-        expected_header = self.expected_header
-        expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
-        expected_header['byte skip'] = -1
-        expected_header['encoding'] = 'gzip'
-        expected_header['data file'] = 'BallBinary30x30x30.nii.gz'
+        def test_read_detached_header_and_nifti_data_with_byteskip_minus1(self):
+            expected_header = self.expected_header
+            expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
+            expected_header['byte skip'] = -1
+            expected_header['encoding'] = 'gzip'
+            expected_header['data file'] = 'BallBinary30x30x30.nii.gz'
 
-        data, header = nrrd.read(GZ_BYTESKIP_NIFTI_NHDR_FILE_PATH, index_order=self.index_order)
+            data, header = nrrd.read(GZ_BYTESKIP_NIFTI_NHDR_FILE_PATH, index_order=self.index_order)
 
-        np.testing.assert_equal(self.expected_header, header)
-        np.testing.assert_equal(data, self.expected_data)
+            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(data, self.expected_data)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_read_detached_header_and_nifti_data(self):
-        with self.assertRaisesRegex(
-                nrrd.NRRDError, 'Size of the data does not equal the product of all the dimensions: 27000-27176=-176'):
-            nrrd.read(GZ_NIFTI_NHDR_FILE_PATH, index_order=self.index_order)
+        def test_read_detached_header_and_nifti_data(self):
+            with self.assertRaisesRegex(
+                    nrrd.NRRDError, 'Size of the data does not equal the product of all the dimensions: 27000-27176=-176'):
+                nrrd.read(GZ_NIFTI_NHDR_FILE_PATH, index_order=self.index_order)
 
-    def test_read_detached_header_and_data_with_byteskip_minus5(self):
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid byteskip, allowed values are greater than or equal to -1'):
-            nrrd.read(RAW_INVALID_BYTESKIP_NHDR_FILE_PATH, index_order=self.index_order)
+        def test_read_detached_header_and_data_with_byteskip_minus5(self):
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid byteskip, allowed values are greater than or equal to -1'):
+                nrrd.read(RAW_INVALID_BYTESKIP_NHDR_FILE_PATH, index_order=self.index_order)
 
-    def test_read_header_and_gz_compressed_data(self):
-        expected_header = self.expected_header
-        expected_header['encoding'] = 'gzip'
+        def test_read_header_and_gz_compressed_data(self):
+            expected_header = self.expected_header
+            expected_header['encoding'] = 'gzip'
 
-        data, header = nrrd.read(GZ_NRRD_FILE_PATH, index_order=self.index_order)
+            data, header = nrrd.read(GZ_NRRD_FILE_PATH, index_order=self.index_order)
 
-        np.testing.assert_equal(self.expected_header, header)
-        np.testing.assert_equal(data, self.expected_data)
+            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(data, self.expected_data)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_read_header_and_gz_compressed_data_with_byteskip_minus1(self):
-        expected_header = self.expected_header
-        expected_header['encoding'] = 'gzip'
-        expected_header['type'] = 'int16'
-        expected_header['byte skip'] = -1
+        def test_read_header_and_gz_compressed_data_with_byteskip_minus1(self):
+            expected_header = self.expected_header
+            expected_header['encoding'] = 'gzip'
+            expected_header['type'] = 'int16'
+            expected_header['byte skip'] = -1
 
-        data, header = nrrd.read(GZ_BYTESKIP_NRRD_FILE_PATH, index_order=self.index_order)
+            data, header = nrrd.read(GZ_BYTESKIP_NRRD_FILE_PATH, index_order=self.index_order)
 
-        np.testing.assert_equal(self.expected_header, header)
-        np.testing.assert_equal(data, self.expected_data)
+            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(data, self.expected_data)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_read_header_and_bz2_compressed_data(self):
-        expected_header = self.expected_header
-        expected_header['encoding'] = 'bzip2'
+        def test_read_header_and_bz2_compressed_data(self):
+            expected_header = self.expected_header
+            expected_header['encoding'] = 'bzip2'
 
-        data, header = nrrd.read(BZ2_NRRD_FILE_PATH, index_order=self.index_order)
+            data, header = nrrd.read(BZ2_NRRD_FILE_PATH, index_order=self.index_order)
 
-        np.testing.assert_equal(self.expected_header, header)
-        np.testing.assert_equal(data, self.expected_data)
+            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(data, self.expected_data)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_read_header_and_gz_compressed_data_with_lineskip3(self):
-        expected_header = self.expected_header
-        expected_header['encoding'] = 'gzip'
-        expected_header['line skip'] = 3
+        def test_read_header_and_gz_compressed_data_with_lineskip3(self):
+            expected_header = self.expected_header
+            expected_header['encoding'] = 'gzip'
+            expected_header['line skip'] = 3
 
-        data, header = nrrd.read(GZ_LINESKIP_NRRD_FILE_PATH, index_order=self.index_order)
+            data, header = nrrd.read(GZ_LINESKIP_NRRD_FILE_PATH, index_order=self.index_order)
 
-        np.testing.assert_equal(self.expected_header, header)
-        np.testing.assert_equal(data, self.expected_data)
+            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(data, self.expected_data)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_read_raw_header(self):
-        expected_header = {'type': 'float', 'dimension': 3, 'min': 0, 'max': 35.4}
-        header = nrrd.read_header(('NRRD0005', 'type: float', 'dimension: 3', 'min: 0', 'max: 35.4'))
-        self.assertEqual(expected_header, header)
-
-        expected_header = {'my extra info': 'my : colon-separated : values'}
-        header = nrrd.read_header(('NRRD0005', 'my extra info:=my : colon-separated : values'))
-        np.testing.assert_equal(expected_header, header)
-
-    def test_read_dup_field_error_and_warn(self):
-        expected_header = {'type': 'float', 'dimension': 3}
-        header_txt_tuple = ('NRRD0005', 'type: float', 'dimension: 3', 'type: float')
-
-        with self.assertRaisesRegex(nrrd.NRRDError, "Duplicate header field: 'type'"):
-            header = nrrd.read_header(header_txt_tuple)
-
-        import warnings
-        with warnings.catch_warnings(record=True) as w:
-            nrrd.reader.ALLOW_DUPLICATE_FIELD = True
-            header = nrrd.read_header(header_txt_tuple)
-
-            self.assertTrue("Duplicate header field: 'type'" in str(w[0].message))
-
+        def test_read_raw_header(self):
+            expected_header = {'type': 'float', 'dimension': 3, 'min': 0, 'max': 35.4}
+            header = nrrd.read_header(('NRRD0005', 'type: float', 'dimension: 3', 'min: 0', 'max: 35.4'))
             self.assertEqual(expected_header, header)
-            nrrd.reader.ALLOW_DUPLICATE_FIELD = False
 
-    def test_read_header_and_ascii_1d_data(self):
-        expected_header = {'dimension': 1,
-                           'encoding': 'ASCII',
-                           'kinds': ['domain'],
-                           'sizes': [27],
-                           'spacings': [1.0458000000000001],
-                           'type': 'unsigned char'}
+            expected_header = {'my extra info': 'my : colon-separated : values'}
+            header = nrrd.read_header(('NRRD0005', 'my extra info:=my : colon-separated : values'))
+            np.testing.assert_equal(expected_header, header)
 
-        data, header = nrrd.read(ASCII_1D_NRRD_FILE_PATH, index_order=self.index_order)
+        def test_read_dup_field_error_and_warn(self):
+            expected_header = {'type': 'float', 'dimension': 3}
+            header_txt_tuple = ('NRRD0005', 'type: float', 'dimension: 3', 'type: float')
 
-        self.assertEqual(header, expected_header)
-        np.testing.assert_equal(data.dtype, np.uint8)
-        np.testing.assert_equal(data, np.arange(1, 28))
+            with self.assertRaisesRegex(nrrd.NRRDError, "Duplicate header field: 'type'"):
+                header = nrrd.read_header(header_txt_tuple)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            import warnings
+            with warnings.catch_warnings(record=True) as w:
+                nrrd.reader.ALLOW_DUPLICATE_FIELD = True
+                header = nrrd.read_header(header_txt_tuple)
 
-    def test_read_header_and_ascii_2d_data(self):
-        expected_header = {'dimension': 2,
-                           'encoding': 'ASCII',
-                           'kinds': ['domain', 'domain'],
-                           'sizes': [3, 9],
-                           'spacings': [1.0458000000000001, 2],
-                           'type': 'unsigned short'}
+                self.assertTrue("Duplicate header field: 'type'" in str(w[0].message))
 
-        data, header = nrrd.read(ASCII_2D_NRRD_FILE_PATH, index_order=self.index_order)
+                self.assertEqual(expected_header, header)
+                nrrd.reader.ALLOW_DUPLICATE_FIELD = False
 
-        np.testing.assert_equal(header, expected_header)
-        np.testing.assert_equal(data.dtype, np.uint16)
+        def test_read_header_and_ascii_1d_data(self):
+            expected_header = {'dimension': 1,
+                            'encoding': 'ASCII',
+                            'kinds': ['domain'],
+                            'sizes': [27],
+                            'spacings': [1.0458000000000001],
+                            'type': 'unsigned char'}
 
-        expected_shape = (3, 9) if self.index_order == 'F' else (9, 3)
-        np.testing.assert_equal(data, np.arange(1, 28).reshape(expected_shape, order=self.index_order))
+            data, header = nrrd.read(ASCII_1D_NRRD_FILE_PATH, index_order=self.index_order)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            self.assertEqual(header, expected_header)
+            np.testing.assert_equal(data.dtype, np.uint8)
+            np.testing.assert_equal(data, np.arange(1, 28))
 
-    def test_read_simple_4d_nrrd(self):
-        expected_header = {'type': 'double',
-                           'dimension': 4,
-                           'space': 'right-anterior-superior',
-                           'sizes': np.array([1, 1, 1, 1]),
-                           'space directions': np.array([[1.5, 0., 0.],
-                                                         [0., 1.5, 0.],
-                                                         [0., 0., 1.],
-                                                         [np.NaN, np.NaN, np.NaN]]),
-                           'endian': 'little',
-                           'encoding': 'raw',
-                           'measurement frame': np.array([[1.0001, 0., 0.],
-                                                          [0., 1.0000000006, 0.],
-                                                          [0., 0., 1.000000000000009]])}
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-        data, header = nrrd.read(RAW_4D_NRRD_FILE_PATH, index_order=self.index_order)
+        def test_read_header_and_ascii_2d_data(self):
+            expected_header = {'dimension': 2,
+                            'encoding': 'ASCII',
+                            'kinds': ['domain', 'domain'],
+                            'sizes': [3, 9],
+                            'spacings': [1.0458000000000001, 2],
+                            'type': 'unsigned short'}
 
-        np.testing.assert_equal(header, expected_header)
-        np.testing.assert_equal(data.dtype, np.float64)
-        np.testing.assert_equal(header['measurement frame'].dtype, np.float64)
-        np.testing.assert_equal(data, np.array([[[[0.76903426]]]]))
+            data, header = nrrd.read(ASCII_2D_NRRD_FILE_PATH, index_order=self.index_order)
 
-        # Test that the data read is able to be edited
-        self.assertTrue(data.flags['WRITEABLE'])
+            np.testing.assert_equal(header, expected_header)
+            np.testing.assert_equal(data.dtype, np.uint16)
 
-    def test_custom_fields_without_field_map(self):
-        expected_header = {'dimension': 1,
-                           'encoding': 'ASCII',
-                           'kinds': ['domain'],
-                           'sizes': [27],
-                           'spacings': [1.0458000000000001],
-                           'int': '24',
-                           'double': '25.5566',
-                           'string': 'This is a long string of information that is important.',
-                           'int list': '1 2 3 4 5 100',
-                           'double list': '0.2 0.502 0.8',
-                           'string list': 'words are split by space in list',
-                           'int vector': '(100, 200, -300)',
-                           'double vector': '(100.5,200.3,-300.99)',
-                           'int matrix': '(1,0,0) (0,1,0) (0,0,1)',
-                           'double matrix': '(1.2,0.3,0) (0,1.5,0) (0,-0.55,1.6)',
-                           'type': 'unsigned char'}
+            expected_shape = (3, 9) if self.index_order == 'F' else (9, 3)
+            np.testing.assert_equal(data, np.arange(1, 28).reshape(expected_shape, order=self.index_order))
 
-        header = nrrd.read_header(ASCII_1D_CUSTOM_FIELDS_FILE_PATH)
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-        self.assertEqual(header, expected_header)
+        def test_read_simple_4d_nrrd(self):
+            expected_header = {'type': 'double',
+                            'dimension': 4,
+                            'space': 'right-anterior-superior',
+                            'sizes': np.array([1, 1, 1, 1]),
+                            'space directions': np.array([[1.5, 0., 0.],
+                                                            [0., 1.5, 0.],
+                                                            [0., 0., 1.],
+                                                            [np.NaN, np.NaN, np.NaN]]),
+                            'endian': 'little',
+                            'encoding': 'raw',
+                            'measurement frame': np.array([[1.0001, 0., 0.],
+                                                            [0., 1.0000000006, 0.],
+                                                            [0., 0., 1.000000000000009]])}
 
-    def test_custom_fields_with_field_map(self):
-        expected_header = {'dimension': 1,
-                           'encoding': 'ASCII',
-                           'kinds': ['domain'],
-                           'sizes': [27],
-                           'spacings': [1.0458000000000001],
-                           'int': 24,
-                           'double': 25.5566,
-                           'string': 'This is a long string of information that is important.',
-                           'int list': np.array([1, 2, 3, 4, 5, 100]),
-                           'double list': np.array([0.2, 0.502, 0.8]),
-                           'string list': ['words', 'are', 'split', 'by', 'space', 'in', 'list'],
-                           'int vector': np.array([100, 200, -300]),
-                           'double vector': np.array([100.5, 200.3, -300.99]),
-                           'int matrix': np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                           'double matrix': np.array([[1.2, 0.3, 0.0], [0.0, 1.5, 0.0], [0.0, -0.55, 1.6]]),
-                           'type': 'unsigned char'}
+            data, header = nrrd.read(RAW_4D_NRRD_FILE_PATH, index_order=self.index_order)
 
-        custom_field_map = {'int': 'int',
-                            'double': 'double',
-                            'string': 'string',
-                            'int list': 'int list',
-                            'double list': 'double list',
-                            'string list': 'string list',
-                            'int vector': 'int vector',
-                            'double vector': 'double vector',
-                            'int matrix': 'int matrix',
-                            'double matrix': 'double matrix'}
-        header = nrrd.read_header(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map)
+            np.testing.assert_equal(header, expected_header)
+            np.testing.assert_equal(data.dtype, np.float64)
+            np.testing.assert_equal(header['measurement frame'].dtype, np.float64)
+            np.testing.assert_equal(data, np.array([[[[0.76903426]]]]))
 
-        np.testing.assert_equal(header, expected_header)
+            # Test that the data read is able to be edited
+            self.assertTrue(data.flags['WRITEABLE'])
 
-    def test_invalid_custom_field(self):
-        custom_field_map = {'int': 'fake'}
+        def test_custom_fields_without_field_map(self):
+            expected_header = {'dimension': 1,
+                            'encoding': 'ASCII',
+                            'kinds': ['domain'],
+                            'sizes': [27],
+                            'spacings': [1.0458000000000001],
+                            'int': '24',
+                            'double': '25.5566',
+                            'string': 'This is a long string of information that is important.',
+                            'int list': '1 2 3 4 5 100',
+                            'double list': '0.2 0.502 0.8',
+                            'string list': 'words are split by space in list',
+                            'int vector': '(100, 200, -300)',
+                            'double vector': '(100.5,200.3,-300.99)',
+                            'int matrix': '(1,0,0) (0,1,0) (0,0,1)',
+                            'double matrix': '(1.2,0.3,0) (0,1.5,0) (0,-0.55,1.6)',
+                            'type': 'unsigned char'}
 
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid field type given: fake'):
-            nrrd.read_header(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map)
+            header = nrrd.read_header(ASCII_1D_CUSTOM_FIELDS_FILE_PATH)
 
-    def test_invalid_magic_line(self):
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid NRRD magic line. Is this an NRRD file?'):
-            nrrd.read_header(('invalid magic line', 'my extra info:=my : colon-separated : values'))
+            self.assertEqual(header, expected_header)
 
-    def test_invalid_magic_line2(self):
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported NRRD file version \\(version: 2000\\). This library '
-                                                    'only supports v5 and below.'):
-            nrrd.read_header(('NRRD2000', 'my extra info:=my : colon-separated : values'))
+        def test_custom_fields_with_field_map(self):
+            expected_header = {'dimension': 1,
+                            'encoding': 'ASCII',
+                            'kinds': ['domain'],
+                            'sizes': [27],
+                            'spacings': [1.0458000000000001],
+                            'int': 24,
+                            'double': 25.5566,
+                            'string': 'This is a long string of information that is important.',
+                            'int list': np.array([1, 2, 3, 4, 5, 100]),
+                            'double list': np.array([0.2, 0.502, 0.8]),
+                            'string list': ['words', 'are', 'split', 'by', 'space', 'in', 'list'],
+                            'int vector': np.array([100, 200, -300]),
+                            'double vector': np.array([100.5, 200.3, -300.99]),
+                            'int matrix': np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+                            'double matrix': np.array([[1.2, 0.3, 0.0], [0.0, 1.5, 0.0], [0.0, -0.55, 1.6]]),
+                            'type': 'unsigned char'}
 
-    def test_invalid_magic_line3(self):
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid NRRD magic line: NRRDnono'):
-            nrrd.read_header(('NRRDnono', 'my extra info:=my : colon-separated : values'))
+            custom_field_map = {'int': 'int',
+                                'double': 'double',
+                                'string': 'string',
+                                'int list': 'int list',
+                                'double list': 'double list',
+                                'string list': 'string list',
+                                'int vector': 'int vector',
+                                'double vector': 'double vector',
+                                'int matrix': 'int matrix',
+                                'double matrix': 'double matrix'}
+            header = nrrd.read_header(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map)
 
-    def test_missing_required_field(self):
-        with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
-            np.testing.assert_equal(self.expected_header, header)
+            np.testing.assert_equal(header, expected_header)
 
-            # Delete required field
-            del header['type']
+        def test_invalid_custom_field(self):
+            custom_field_map = {'int': 'fake'}
 
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Header is missing required field: "type".'):
-                nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid field type given: fake'):
+                nrrd.read_header(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map)
 
-    def test_wrong_sizes(self):
-        with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
-            np.testing.assert_equal(self.expected_header, header)
+        def test_invalid_magic_line(self):
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid NRRD magic line. Is this an NRRD file?'):
+                nrrd.read_header(('invalid magic line', 'my extra info:=my : colon-separated : values'))
 
-            # Make the number of dimensions wrong
-            header['dimension'] = 2
+        def test_invalid_magic_line2(self):
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported NRRD file version \\(version: 2000\\). This library '
+                                                        'only supports v5 and below.'):
+                nrrd.read_header(('NRRD2000', 'my extra info:=my : colon-separated : values'))
 
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Number of elements in sizes does not match dimension. '
-                                                        'Dimension: 2, len\\(sizes\\): 3'):
-                nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
+        def test_invalid_magic_line3(self):
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid NRRD magic line: NRRDnono'):
+                nrrd.read_header(('NRRDnono', 'my extra info:=my : colon-separated : values'))
 
-    def test_invalid_encoding(self):
-        with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
-            np.testing.assert_equal(self.expected_header, header)
+        def test_missing_required_field(self):
+            with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
+                np.testing.assert_equal(self.expected_header, header)
 
-            # Set the encoding to be incorrect
-            header['encoding'] = 'fake'
+                # Delete required field
+                del header['type']
 
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported encoding: "fake"'):
-                nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
+                with self.assertRaisesRegex(nrrd.NRRDError, 'Header is missing required field: "type".'):
+                    nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
-    def test_detached_header_no_filename(self):
-        self.expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
+        def test_wrong_sizes(self):
+            with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
+                np.testing.assert_equal(self.expected_header, header)
 
-        with open(RAW_NHDR_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
-            np.testing.assert_equal(self.expected_header, header)
+                # Make the number of dimensions wrong
+                header['dimension'] = 2
 
-            # No filename is specified for read_data
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Filename parameter must be specified when a relative data file'
-                                                        ' path is given'):
-                nrrd.read_data(header, fh)
+                with self.assertRaisesRegex(nrrd.NRRDError, 'Number of elements in sizes does not match dimension. '
+                                                            'Dimension: 2, len\\(sizes\\): 3'):
+                    nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
-    def test_invalid_lineskip(self):
-        with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
-            np.testing.assert_equal(self.expected_header, header)
+        def test_invalid_encoding(self):
+            with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
+                np.testing.assert_equal(self.expected_header, header)
 
-            # Set the line skip to be incorrect
-            header['line skip'] = -1
+                # Set the encoding to be incorrect
+                header['encoding'] = 'fake'
 
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid lineskip, allowed values are greater than or equal to'
-                                                        ' 0'):
-                nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
+                with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported encoding: "fake"'):
+                    nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
-    def test_missing_endianness(self):
-        with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
-            np.testing.assert_equal(self.expected_header, header)
+        def test_detached_header_no_filename(self):
+            self.expected_header['data file'] = os.path.basename(RAW_DATA_FILE_PATH)
 
-            # Delete the endian field from header
-            # Since our data is short (itemsize = 2), we should receive an error
-            del header['endian']
+            with open(RAW_NHDR_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
+                np.testing.assert_equal(self.expected_header, header)
 
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Header is missing required field: "endian".'):
-                nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
+                # No filename is specified for read_data
+                with self.assertRaisesRegex(nrrd.NRRDError, 'Filename parameter must be specified when a relative data file'
+                                                            ' path is given'):
+                    nrrd.read_data(header, fh)
 
-    def test_big_endian(self):
-        with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
-            np.testing.assert_equal(self.expected_header, header)
+        def test_invalid_lineskip(self):
+            with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
+                np.testing.assert_equal(self.expected_header, header)
 
-            # Set endianness to big to verify it is doing correctly
-            header['endian'] = 'big'
+                # Set the line skip to be incorrect
+                header['line skip'] = -1
 
-            data = nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
-            np.testing.assert_equal(data, self.expected_data.byteswap())
+                with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid lineskip, allowed values are greater than or equal to'
+                                                            ' 0'):
+                    nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
-    def test_invalid_endian(self):
-        with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
-            header = nrrd.read_header(fh)
-            np.testing.assert_equal(self.expected_header, header)
+        def test_missing_endianness(self):
+            with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
+                np.testing.assert_equal(self.expected_header, header)
 
-            # Set endianness to fake value
-            header['endian'] = 'fake'
+                # Delete the endian field from header
+                # Since our data is short (itemsize = 2), we should receive an error
+                del header['endian']
 
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid endian value in header: "fake"'):
-                nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
+                with self.assertRaisesRegex(nrrd.NRRDError, 'Header is missing required field: "endian".'):
+                    nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
-    def test_invalid_index_order(self):
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid index order'):
-            nrrd.read(RAW_NRRD_FILE_PATH, index_order=None)
+        def test_big_endian(self):
+            with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
+                np.testing.assert_equal(self.expected_header, header)
 
-    def test_read_quoted_string_header(self):
-        header = nrrd.read_header([
-            'NRRD0004',
-            '# Complete NRRD file format specification at:',
-            '# http://teem.sourceforge.net/nrrd/format.html',
-            'type: double',
-            'dimension: 3',
-            'space dimension: 3',
-            'sizes: 32 40 16',
-            'encoding: raw',
-            'units: "mm" "cm" "in"',
-            'space units: "mm" "cm" "in"',
-            'labels: "X" "Y" "f(log(X, 10), Y)"',
-            'space origin: (-0.79487200000000002,-1,-0.38461499999999998)'
-        ])
+                # Set endianness to big to verify it is doing correctly
+                header['endian'] = 'big'
 
-        # Check that the quoted values were appropriately parsed
-        self.assertEqual(['mm', 'cm', 'in'], header['units'])
-        self.assertEqual(['mm', 'cm', 'in'], header['space units'])
-        self.assertEqual(['X', 'Y', 'f(log(X, 10), Y)'], header['labels'])
+                data = nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
+                np.testing.assert_equal(data, self.expected_data.byteswap())
 
-    def test_read_quoted_string_header_no_quotes(self):
-        header = nrrd.read_header([
-            'NRRD0004',
-            '# Complete NRRD file format specification at:',
-            '# http://teem.sourceforge.net/nrrd/format.html',
-            'type: double',
-            'dimension: 3',
-            'space dimension: 3',
-            'sizes: 32 40 16',
-            'encoding: raw',
-            'units: mm cm in',
-            'space units: mm cm in',
-            'labels: X Y f(log(X,10),Y)',
-            'space origin: (-0.79487200000000002,-1,-0.38461499999999998)'
-        ])
+        def test_invalid_endian(self):
+            with open(RAW_NRRD_FILE_PATH, 'rb') as fh:
+                header = nrrd.read_header(fh)
+                np.testing.assert_equal(self.expected_header, header)
 
-        # Check that the quoted values were appropriately parsed
-        self.assertEqual(['mm', 'cm', 'in'], header['units'])
-        self.assertEqual(['mm', 'cm', 'in'], header['space units'])
-        self.assertEqual(['X', 'Y', 'f(log(X,10),Y)'], header['labels'])
+                # Set endianness to fake value
+                header['endian'] = 'fake'
+
+                with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid endian value in header: "fake"'):
+                    nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
+
+        def test_invalid_index_order(self):
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid index order'):
+                nrrd.read(RAW_NRRD_FILE_PATH, index_order=None)
+
+        def test_read_quoted_string_header(self):
+            header = nrrd.read_header([
+                'NRRD0004',
+                '# Complete NRRD file format specification at:',
+                '# http://teem.sourceforge.net/nrrd/format.html',
+                'type: double',
+                'dimension: 3',
+                'space dimension: 3',
+                'sizes: 32 40 16',
+                'encoding: raw',
+                'units: "mm" "cm" "in"',
+                'space units: "mm" "cm" "in"',
+                'labels: "X" "Y" "f(log(X, 10), Y)"',
+                'space origin: (-0.79487200000000002,-1,-0.38461499999999998)'
+            ])
+
+            # Check that the quoted values were appropriately parsed
+            self.assertEqual(['mm', 'cm', 'in'], header['units'])
+            self.assertEqual(['mm', 'cm', 'in'], header['space units'])
+            self.assertEqual(['X', 'Y', 'f(log(X, 10), Y)'], header['labels'])
+
+        def test_read_quoted_string_header_no_quotes(self):
+            header = nrrd.read_header([
+                'NRRD0004',
+                '# Complete NRRD file format specification at:',
+                '# http://teem.sourceforge.net/nrrd/format.html',
+                'type: double',
+                'dimension: 3',
+                'space dimension: 3',
+                'sizes: 32 40 16',
+                'encoding: raw',
+                'units: mm cm in',
+                'space units: mm cm in',
+                'labels: X Y f(log(X,10),Y)',
+                'space origin: (-0.79487200000000002,-1,-0.38461499999999998)'
+            ])
+
+            # Check that the quoted values were appropriately parsed
+            self.assertEqual(['mm', 'cm', 'in'], header['units'])
+            self.assertEqual(['mm', 'cm', 'in'], header['space units'])
+            self.assertEqual(['X', 'Y', 'f(log(X,10),Y)'], header['labels'])
 
 
-class TestReadingFunctionsFortran(TestReadingFunctions, unittest.TestCase):
+class TestReadingFunctionsFortran(Abstract.TestReadingFunctions):
     index_order = 'F'
 
 
-class TestReadingFunctionsC(TestReadingFunctions, unittest.TestCase):
+class TestReadingFunctionsC(Abstract.TestReadingFunctions):
     index_order = 'C'
 
 

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -1,7 +1,8 @@
 import unittest
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 import numpy as np
+from typing_extensions import Literal
 
 import nrrd
 from nrrd.tests.util import *

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -31,16 +31,16 @@ class Abstract:
                 header = nrrd.read_header(fh)
 
             # np.testing.assert_equal is used to compare the headers because it will appropriately handle each
-            # value in the structure. Since some of the values can be Numpy arrays inside the headers, this must be
-            # used to compare the two values.
+            # value in the structure. Since some values can be Numpy arrays inside the headers, this must be used to
+            # compare the two values.
             np.testing.assert_equal(self.expected_header, header)
 
         def test_read_header_only_with_filename(self):
             header = nrrd.read_header(RAW_NRRD_FILE_PATH)
 
             # np.testing.assert_equal is used to compare the headers because it will appropriately handle each
-            # value in the structure. Since some of the values can be Numpy arrays inside the headers, this must be
-            # used to compare the two values.
+            # value in the structure. Since some values can be Numpy arrays inside the headers, this must be used to
+            # compare the two values.
             np.testing.assert_equal(self.expected_header, header)
 
         def test_read_detached_header_only(self):

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -103,11 +103,13 @@ class Abstract:
 
         def test_read_detached_header_and_nifti_data(self):
             with self.assertRaisesRegex(
-                    nrrd.NRRDError, 'Size of the data does not equal the product of all the dimensions: 27000-27176=-176'):
+                    nrrd.NRRDError,
+                    'Size of the data does not equal the product of all the dimensions: 27000-27176=-176'):
                 nrrd.read(GZ_NIFTI_NHDR_FILE_PATH, index_order=self.index_order)
 
         def test_read_detached_header_and_data_with_byteskip_minus5(self):
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid byteskip, allowed values are greater than or equal to -1'):
+            with self.assertRaisesRegex(nrrd.NRRDError,
+                                        'Invalid byteskip, allowed values are greater than or equal to -1'):
                 nrrd.read(RAW_INVALID_BYTESKIP_NHDR_FILE_PATH, index_order=self.index_order)
 
         def test_read_header_and_gz_compressed_data(self):
@@ -189,11 +191,11 @@ class Abstract:
 
         def test_read_header_and_ascii_1d_data(self):
             expected_header = {'dimension': 1,
-                            'encoding': 'ASCII',
-                            'kinds': ['domain'],
-                            'sizes': [27],
-                            'spacings': [1.0458000000000001],
-                            'type': 'unsigned char'}
+                               'encoding': 'ASCII',
+                               'kinds': ['domain'],
+                               'sizes': [27],
+                               'spacings': [1.0458000000000001],
+                               'type': 'unsigned char'}
 
             data, header = nrrd.read(ASCII_1D_NRRD_FILE_PATH, index_order=self.index_order)
 
@@ -206,11 +208,11 @@ class Abstract:
 
         def test_read_header_and_ascii_2d_data(self):
             expected_header = {'dimension': 2,
-                            'encoding': 'ASCII',
-                            'kinds': ['domain', 'domain'],
-                            'sizes': [3, 9],
-                            'spacings': [1.0458000000000001, 2],
-                            'type': 'unsigned short'}
+                               'encoding': 'ASCII',
+                               'kinds': ['domain', 'domain'],
+                               'sizes': [3, 9],
+                               'spacings': [1.0458000000000001, 2],
+                               'type': 'unsigned short'}
 
             data, header = nrrd.read(ASCII_2D_NRRD_FILE_PATH, index_order=self.index_order)
 
@@ -225,18 +227,18 @@ class Abstract:
 
         def test_read_simple_4d_nrrd(self):
             expected_header = {'type': 'double',
-                            'dimension': 4,
-                            'space': 'right-anterior-superior',
-                            'sizes': np.array([1, 1, 1, 1]),
-                            'space directions': np.array([[1.5, 0., 0.],
-                                                            [0., 1.5, 0.],
-                                                            [0., 0., 1.],
-                                                            [np.NaN, np.NaN, np.NaN]]),
-                            'endian': 'little',
-                            'encoding': 'raw',
-                            'measurement frame': np.array([[1.0001, 0., 0.],
-                                                            [0., 1.0000000006, 0.],
-                                                            [0., 0., 1.000000000000009]])}
+                               'dimension': 4,
+                               'space': 'right-anterior-superior',
+                               'sizes': np.array([1, 1, 1, 1]),
+                               'space directions': np.array([[1.5, 0., 0.],
+                                                             [0., 1.5, 0.],
+                                                             [0., 0., 1.],
+                                                             [np.NaN, np.NaN, np.NaN]]),
+                               'endian': 'little',
+                               'encoding': 'raw',
+                               'measurement frame': np.array([[1.0001, 0., 0.],
+                                                              [0., 1.0000000006, 0.],
+                                                              [0., 0., 1.000000000000009]])}
 
             data, header = nrrd.read(RAW_4D_NRRD_FILE_PATH, index_order=self.index_order)
 
@@ -250,21 +252,21 @@ class Abstract:
 
         def test_custom_fields_without_field_map(self):
             expected_header = {'dimension': 1,
-                            'encoding': 'ASCII',
-                            'kinds': ['domain'],
-                            'sizes': [27],
-                            'spacings': [1.0458000000000001],
-                            'int': '24',
-                            'double': '25.5566',
-                            'string': 'This is a long string of information that is important.',
-                            'int list': '1 2 3 4 5 100',
-                            'double list': '0.2 0.502 0.8',
-                            'string list': 'words are split by space in list',
-                            'int vector': '(100, 200, -300)',
-                            'double vector': '(100.5,200.3,-300.99)',
-                            'int matrix': '(1,0,0) (0,1,0) (0,0,1)',
-                            'double matrix': '(1.2,0.3,0) (0,1.5,0) (0,-0.55,1.6)',
-                            'type': 'unsigned char'}
+                               'encoding': 'ASCII',
+                               'kinds': ['domain'],
+                               'sizes': [27],
+                               'spacings': [1.0458000000000001],
+                               'int': '24',
+                               'double': '25.5566',
+                               'string': 'This is a long string of information that is important.',
+                               'int list': '1 2 3 4 5 100',
+                               'double list': '0.2 0.502 0.8',
+                               'string list': 'words are split by space in list',
+                               'int vector': '(100, 200, -300)',
+                               'double vector': '(100.5,200.3,-300.99)',
+                               'int matrix': '(1,0,0) (0,1,0) (0,0,1)',
+                               'double matrix': '(1.2,0.3,0) (0,1.5,0) (0,-0.55,1.6)',
+                               'type': 'unsigned char'}
 
             header = nrrd.read_header(ASCII_1D_CUSTOM_FIELDS_FILE_PATH)
 
@@ -272,21 +274,21 @@ class Abstract:
 
         def test_custom_fields_with_field_map(self):
             expected_header = {'dimension': 1,
-                            'encoding': 'ASCII',
-                            'kinds': ['domain'],
-                            'sizes': [27],
-                            'spacings': [1.0458000000000001],
-                            'int': 24,
-                            'double': 25.5566,
-                            'string': 'This is a long string of information that is important.',
-                            'int list': np.array([1, 2, 3, 4, 5, 100]),
-                            'double list': np.array([0.2, 0.502, 0.8]),
-                            'string list': ['words', 'are', 'split', 'by', 'space', 'in', 'list'],
-                            'int vector': np.array([100, 200, -300]),
-                            'double vector': np.array([100.5, 200.3, -300.99]),
-                            'int matrix': np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
-                            'double matrix': np.array([[1.2, 0.3, 0.0], [0.0, 1.5, 0.0], [0.0, -0.55, 1.6]]),
-                            'type': 'unsigned char'}
+                               'encoding': 'ASCII',
+                               'kinds': ['domain'],
+                               'sizes': [27],
+                               'spacings': [1.0458000000000001],
+                               'int': 24,
+                               'double': 25.5566,
+                               'string': 'This is a long string of information that is important.',
+                               'int list': np.array([1, 2, 3, 4, 5, 100]),
+                               'double list': np.array([0.2, 0.502, 0.8]),
+                               'string list': ['words', 'are', 'split', 'by', 'space', 'in', 'list'],
+                               'int vector': np.array([100, 200, -300]),
+                               'double vector': np.array([100.5, 200.3, -300.99]),
+                               'int matrix': np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]),
+                               'double matrix': np.array([[1.2, 0.3, 0.0], [0.0, 1.5, 0.0], [0.0, -0.55, 1.6]]),
+                               'type': 'unsigned char'}
 
             custom_field_map = {'int': 'int',
                                 'double': 'double',
@@ -313,8 +315,9 @@ class Abstract:
                 nrrd.read_header(('invalid magic line', 'my extra info:=my : colon-separated : values'))
 
         def test_invalid_magic_line2(self):
-            with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported NRRD file version \\(version: 2000\\). This library '
-                                                        'only supports v5 and below.'):
+            with self.assertRaisesRegex(nrrd.NRRDError,
+                                        'Unsupported NRRD file version \\(version: 2000\\). This library '
+                                        'only supports v5 and below.'):
                 nrrd.read_header(('NRRD2000', 'my extra info:=my : colon-separated : values'))
 
         def test_invalid_magic_line3(self):
@@ -363,8 +366,9 @@ class Abstract:
                 np.testing.assert_equal(self.expected_header, header)
 
                 # No filename is specified for read_data
-                with self.assertRaisesRegex(nrrd.NRRDError, 'Filename parameter must be specified when a relative data file'
-                                                            ' path is given'):
+                with self.assertRaisesRegex(nrrd.NRRDError,
+                                            'Filename parameter must be specified when a relative data file'
+                                            ' path is given'):
                     nrrd.read_data(header, fh)
 
         def test_invalid_lineskip(self):
@@ -375,8 +379,9 @@ class Abstract:
                 # Set the line skip to be incorrect
                 header['line skip'] = -1
 
-                with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid lineskip, allowed values are greater than or equal to'
-                                                            ' 0'):
+                with self.assertRaisesRegex(nrrd.NRRDError,
+                                            'Invalid lineskip, allowed values are greater than or equal to'
+                                            ' 0'):
                     nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
         def test_missing_endianness(self):

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -8,395 +8,396 @@ import nrrd
 from nrrd.tests.util import *
 
 
-class TestWritingFunctions:
-    def setUp(self):
-        self.temp_write_dir = tempfile.mkdtemp('nrrdtest')
-        self.data_input, _ = nrrd.read(RAW_NRRD_FILE_PATH, index_order=self.index_order)
-
-        with open(RAW_DATA_FILE_PATH, 'rb') as fh:
-            self.expected_data = fh.read()
-
-    def write_and_read_back(self, encoding=None, level=9):
-        output_filename = os.path.join(self.temp_write_dir, f'testfile_{encoding}_{str(level)}.nrrd')
-        headers = {}
-        if encoding is not None:
-            headers['encoding'] = encoding
-        nrrd.write(output_filename, self.data_input, headers, compression_level=level,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(header.get('encoding'), encoding or 'gzip')  # default is gzip is not specified
-
-        return output_filename
-
-    def test_write_default_header(self):
-        self.write_and_read_back()
-
-    def test_write_raw(self):
-        self.write_and_read_back('raw')
-
-    def test_write_gz(self):
-        self.write_and_read_back('gzip')
-
-    def test_write_bzip2(self):
-        self.write_and_read_back('bzip2')
-
-    def test_write_gz_level1(self):
-        filename = self.write_and_read_back('gzip', level=1)
-
-        self.assertLess(os.path.getsize(GZ_NRRD_FILE_PATH), os.path.getsize(filename))
-
-    def test_write_bzip2_level1(self):
-        _ = self.write_and_read_back('bzip2', level=1)
-
-        # note: we don't currently assert reduction here, because with the binary ball test data,
-        #       the output size does not change at different bz2 levels.
-        # self.assertLess(os.path.getsize(BZ2_NRRD_FILE_PATH), os.path.getsize(fn))
-
-    def test_write_ascii_1d(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_1d.nrrd')
-
-        x = np.arange(1, 28)
-        nrrd.write(output_filename, x, {'encoding': 'ascii'}, index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(header['encoding'], 'ascii')
-        np.testing.assert_equal(data, x)
-
-    def test_write_ascii_2d(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_2d.nrrd')
-
-        x = np.arange(1, 28).reshape((3, 9), order=self.index_order)
-        nrrd.write(output_filename, x, {'encoding': 'ascii'}, index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(header['encoding'], 'ascii')
-        np.testing.assert_equal(data, x)
-
-    def test_write_ascii_3d(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_3d.nrrd')
-
-        x = np.arange(1, 28).reshape((3, 3, 3), order=self.index_order)
-        nrrd.write(output_filename, x, {'encoding': 'ascii'}, index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(header['encoding'], 'ascii')
-        np.testing.assert_equal(x, data)
-
-    def test_write_custom_fields_without_custom_field_map(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_custom_fields.nrrd')
-
-        data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, index_order=self.index_order)
-        nrrd.write(output_filename, data, header, index_order=self.index_order)
-
-        with open(output_filename) as fh:
-            lines = fh.readlines()
-
-            # Strip newline from end of line
-            lines = [line.rstrip() for line in lines]
-
-            self.assertEqual(lines[5], 'type: uint8')
-            self.assertEqual(lines[6], 'dimension: 1')
-            self.assertEqual(lines[7], 'sizes: 27')
-            self.assertEqual(lines[8], 'kinds: domain')
-            self.assertEqual(lines[9], 'encoding: ASCII')
-            self.assertEqual(lines[10], 'spacings: 1.0458000000000001')
-            self.assertEqual(lines[11], 'int:=24')
-            self.assertEqual(lines[12], 'double:=25.5566')
-            self.assertEqual(lines[13], 'string:=This is a long string of information that is important.')
-            self.assertEqual(lines[14], 'int list:=1 2 3 4 5 100')
-            self.assertEqual(lines[15], 'double list:=0.2 0.502 0.8')
-            self.assertEqual(lines[16], 'string list:=words are split by space in list')
-            self.assertEqual(lines[17], 'int vector:=(100, 200, -300)')
-            self.assertEqual(lines[18], 'double vector:=(100.5,200.3,-300.99)')
-            self.assertEqual(lines[19], 'int matrix:=(1,0,0) (0,1,0) (0,0,1)')
-            self.assertEqual(lines[20], 'double matrix:=(1.2,0.3,0) (0,1.5,0) (0,-0.55,1.6)')
-
-    def test_write_custom_fields_with_custom_field_map(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_custom_fields.nrrd')
-
-        custom_field_map = {'int': 'int',
-                            'double': 'double',
-                            'string': 'string',
-                            'int list': 'int list',
-                            'double list': 'double list',
-                            'string list': 'string list',
-                            'int vector': 'int vector',
-                            'double vector': 'double vector',
-                            'int matrix': 'int matrix',
-                            'double matrix': 'double matrix'}
-
-        data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map, index_order=self.index_order)
-        nrrd.write(output_filename, data, header, custom_field_map=custom_field_map, index_order=self.index_order)
-
-        with open(output_filename) as fh:
-            lines = fh.readlines()
-
-            # Strip newline from end of line
-            lines = [line.rstrip() for line in lines]
-
-            self.assertEqual(lines[5], 'type: uint8')
-            self.assertEqual(lines[6], 'dimension: 1')
-            self.assertEqual(lines[7], 'sizes: 27')
-            self.assertEqual(lines[8], 'kinds: domain')
-            self.assertEqual(lines[9], 'encoding: ASCII')
-            self.assertEqual(lines[10], 'spacings: 1.0458000000000001')
-            self.assertEqual(lines[11], 'int:=24')
-            self.assertEqual(lines[12], 'double:=25.5566')
-            self.assertEqual(lines[13], 'string:=This is a long string of information that is important.')
-            self.assertEqual(lines[14], 'int list:=1 2 3 4 5 100')
-            self.assertEqual(lines[15], 'double list:=0.20000000000000001 0.502 0.80000000000000004')
-            self.assertEqual(lines[16], 'string list:=words are split by space in list')
-            self.assertEqual(lines[17], 'int vector:=(100,200,-300)')
-            self.assertEqual(lines[18], 'double vector:=(100.5,200.30000000000001,-300.99000000000001)')
-            self.assertEqual(lines[19], 'int matrix:=(1,0,0) (0,1,0) (0,0,1)')
-            self.assertEqual(lines[20], 'double matrix:=(1.2,0.29999999999999999,0) (0,1.5,0) (0,-0.55000000000000004,'
-                                        '1.6000000000000001)')
-
-    def test_write_detached_raw_as_nrrd(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
-        output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nrrd')
-
-        nrrd.write(output_data_filename, self.data_input, {'encoding': 'raw'}, detached_header=True,
-                   relative_data_path=False, index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(header['encoding'], 'raw')
-        self.assertEqual(header['data file'], output_data_filename)
-
-    def test_write_detached_raw_odd_extension(self):
-        output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nrrd2')
-
-        nrrd.write(output_data_filename, self.data_input, {'encoding': 'raw'}, detached_header=True,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_data_filename, index_order=self.index_order)
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(header['encoding'], 'raw')
-        self.assertEqual('data file' in header, False)
-
-    def test_write_fake_encoding(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
-
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid encoding specification while writing NRRD file: fake'):
-            nrrd.write(output_filename, self.data_input, {'encoding': 'fake'}, index_order=self.index_order)
-
-    def test_write_detached_raw(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
-
-        # Data & header are still detached even though detached_header is False because the filename is .nhdr
-        # Test also checks detached data filename that it is relative (default value)
-        nrrd.write(output_filename, self.data_input, {'encoding': 'raw'}, detached_header=False,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(header['encoding'], 'raw')
-        self.assertEqual(header['data file'], 'testfile_detached_raw.raw')
-
-    def test_write_detached_gz(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
-        output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.raw.gz')
-
-        # Data & header are still detached even though detached_header is False because the filename is .nhdr
-        # Test also checks detached data filename that it is absolute
-        nrrd.write(output_filename, self.data_input, {'encoding': 'gz'}, detached_header=False,
-                   relative_data_path=False, index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(header['encoding'], 'gz')
-        self.assertEqual(header['data file'], output_data_filename)
-
-    def test_write_detached_bz2(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
-
-        # Data & header are still detached even though detached_header is False because the filename is .nhdr
-        # Test also checks detached data filename that it is relative (default value)
-        nrrd.write(output_filename, self.data_input, {'encoding': 'bz2'}, detached_header=False,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(header['encoding'], 'bz2')
-        self.assertEqual(header['data file'], 'testfile_detached_raw.raw.bz2')
-
-    def test_write_detached_ascii(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
-
-        # Data & header are still detached even though detached_header is False because the filename is .nhdr
-        # Test also checks detached data filename that it is relative (default value)
-        nrrd.write(output_filename, self.data_input, {'encoding': 'txt'}, detached_header=False,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(header['encoding'], 'txt')
-        self.assertEqual(header['data file'], 'testfile_detached_raw.txt')
-
-    def test_invalid_custom_field(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_invalid_custom_field.nrrd')
-        header = {'int': 12}
-        custom_field_map = {'int': 'fake'}
-
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid field type given: fake'):
-            nrrd.write(output_filename, np.zeros((3, 9)), header, custom_field_map=custom_field_map,
-                       index_order=self.index_order)
-
-    def test_remove_endianness(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_remove_endianness.nrrd')
-
-        x = np.arange(1, 28)
-        nrrd.write(output_filename, x, {'encoding': 'ascii', 'endian': 'little', 'space': 'right-anterior-superior',
-                                        'space dimension': 3}, index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(header['encoding'], 'ascii')
-
-        # Check for endian and space dimension, both of these should have been removed from the header
-        # Endian because it is an ASCII encoded file and space dimension because space is specified
-        self.assertFalse('endian' in header)
-        self.assertFalse('space dimension' in header)
-        np.testing.assert_equal(data, x)
-
-    def test_unsupported_encoding(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_unsupported_encoding.nrrd')
-        header = {'encoding': 'fake'}
-
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported encoding: "fake"'):
-            nrrd.write(output_filename, np.zeros((3, 9)), header, index_order=self.index_order)
-
-    def test_invalid_index_order(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_invalid_index_order.nrrd')
-
-        with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid index order'):
-            nrrd.write(output_filename, np.zeros((3, 9)), index_order=None)
-
-    def test_quoted_string_list_header(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_3d.nrrd')
-
-        x = np.arange(1, 28).reshape((3, 3, 3), order=self.index_order)
-        nrrd.write(output_filename, x, {
-            'encoding': 'ascii',
-            'units': ['mm', 'cm', 'in'],
-            'space units': ['mm', 'cm', 'in'],
-            'labels': ['X', 'Y', 'f(log(X, 10), Y)'],
-        }, index_order=self.index_order)
-
-        with open(output_filename) as fh:
-            lines = fh.readlines()
-
-            # Strip newline from end of line
-            lines = [line.rstrip() for line in lines]
-
-            # Note the order of the lines dont matter, we just want to verify theyre outputted correctly
-            self.assertTrue('units: "mm" "cm" "in"' in lines)
-            self.assertTrue('space units: "mm" "cm" "in"' in lines)
-            self.assertTrue('labels: "X" "Y" "f(log(X, 10), Y)"' in lines)
-
-    def test_write_detached_datafile_check(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
-
-        nrrd.write(output_filename, self.data_input, {'datafile': 'testfile_detachedWRONG.gz'}, detached_header=True,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(header['data file'], 'testfile_detached.raw.gz')
-
-    def test_write_detached_datafile_check2(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
-
-        nrrd.write(output_filename, self.data_input, {'data file': 'testfile_detachedWRONG.gz'}, detached_header=True,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(header['data file'], 'testfile_detached.raw.gz')
-
-    def test_write_detached_datafile_custom_name(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
-        # Specify a custom path to write the
-        output_header_filename = os.path.join(self.temp_write_dir, 'testfile_detachedDifferent.gz')
-
-        nrrd.write(output_filename, self.data_input, detached_header=output_header_filename,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertEqual(header['data file'], 'testfile_detachedDifferent.gz')
-
-    def test_write_check_remove_datafile(self):
-        output_filename = os.path.join(self.temp_write_dir, 'testfile.nrrd')
-
-        nrrd.write(output_filename, self.data_input, {'data file': 'testfile_detached.gz'}, detached_header=False,
-                   index_order=self.index_order)
-
-        # Read back the same file
-        # The 'data file' parameter should be missing since this is NOT a detached file
-        data, header = nrrd.read(output_filename, index_order=self.index_order)
-        self.assertFalse('data file' in header)
-
-    def test_write_memory(self):
-        default_output_filename = os.path.join(self.temp_write_dir, 'testfile_default_filename.nrrd')
-        nrrd.write(default_output_filename, self.data_input, {}, index_order=self.index_order)
-
-        memory_nrrd = io.BytesIO()
-
-        nrrd.write(memory_nrrd, self.data_input, {}, index_order=self.index_order)
-
-        memory_nrrd.seek(0)
-
-        data, header = nrrd.read(default_output_filename, index_order=self.index_order)
-        memory_header = nrrd.read_header(memory_nrrd)
-        memory_data = nrrd.read_data(header=memory_header, fh=memory_nrrd, filename=None, index_order=self.index_order)
-
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(self.expected_data, memory_data.tobytes(order=self.index_order))
-        self.assertEqual(header.pop('sizes').all(), memory_header.pop('sizes').all())
-        self.assertSequenceEqual(header, memory_header)
-
-    def test_write_memory_file_handle(self):
-        default_output_filename = os.path.join(self.temp_write_dir, 'testfile_default_filename.nrrd')
-        nrrd.write(default_output_filename, self.data_input, {}, index_order=self.index_order)
-
-        default_output_memory_filename = os.path.join(self.temp_write_dir, 'testfile_default_memory_filename.nrrd')
-
-        with open(default_output_memory_filename, mode='wb') as memory_nrrd:
+class Abstract:
+    class TestWritingFunctions(unittest.TestCase):
+        def setUp(self):
+            self.temp_write_dir = tempfile.mkdtemp('nrrdtest')
+            self.data_input, _ = nrrd.read(RAW_NRRD_FILE_PATH, index_order=self.index_order)
+
+            with open(RAW_DATA_FILE_PATH, 'rb') as fh:
+                self.expected_data = fh.read()
+
+        def write_and_read_back(self, encoding=None, level=9):
+            output_filename = os.path.join(self.temp_write_dir, f'testfile_{encoding}_{str(level)}.nrrd')
+            headers = {}
+            if encoding is not None:
+                headers['encoding'] = encoding
+            nrrd.write(output_filename, self.data_input, headers, compression_level=level,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(header.get('encoding'), encoding or 'gzip')  # default is gzip is not specified
+
+            return output_filename
+
+        def test_write_default_header(self):
+            self.write_and_read_back()
+
+        def test_write_raw(self):
+            self.write_and_read_back('raw')
+
+        def test_write_gz(self):
+            self.write_and_read_back('gzip')
+
+        def test_write_bzip2(self):
+            self.write_and_read_back('bzip2')
+
+        def test_write_gz_level1(self):
+            filename = self.write_and_read_back('gzip', level=1)
+
+            self.assertLess(os.path.getsize(GZ_NRRD_FILE_PATH), os.path.getsize(filename))
+
+        def test_write_bzip2_level1(self):
+            _ = self.write_and_read_back('bzip2', level=1)
+
+            # note: we don't currently assert reduction here, because with the binary ball test data,
+            #       the output size does not change at different bz2 levels.
+            # self.assertLess(os.path.getsize(BZ2_NRRD_FILE_PATH), os.path.getsize(fn))
+
+        def test_write_ascii_1d(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_1d.nrrd')
+
+            x = np.arange(1, 28)
+            nrrd.write(output_filename, x, {'encoding': 'ascii'}, index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(header['encoding'], 'ascii')
+            np.testing.assert_equal(data, x)
+
+        def test_write_ascii_2d(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_2d.nrrd')
+
+            x = np.arange(1, 28).reshape((3, 9), order=self.index_order)
+            nrrd.write(output_filename, x, {'encoding': 'ascii'}, index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(header['encoding'], 'ascii')
+            np.testing.assert_equal(data, x)
+
+        def test_write_ascii_3d(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_3d.nrrd')
+
+            x = np.arange(1, 28).reshape((3, 3, 3), order=self.index_order)
+            nrrd.write(output_filename, x, {'encoding': 'ascii'}, index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(header['encoding'], 'ascii')
+            np.testing.assert_equal(x, data)
+
+        def test_write_custom_fields_without_custom_field_map(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_custom_fields.nrrd')
+
+            data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, index_order=self.index_order)
+            nrrd.write(output_filename, data, header, index_order=self.index_order)
+
+            with open(output_filename) as fh:
+                lines = fh.readlines()
+
+                # Strip newline from end of line
+                lines = [line.rstrip() for line in lines]
+
+                self.assertEqual(lines[5], 'type: uint8')
+                self.assertEqual(lines[6], 'dimension: 1')
+                self.assertEqual(lines[7], 'sizes: 27')
+                self.assertEqual(lines[8], 'kinds: domain')
+                self.assertEqual(lines[9], 'encoding: ASCII')
+                self.assertEqual(lines[10], 'spacings: 1.0458000000000001')
+                self.assertEqual(lines[11], 'int:=24')
+                self.assertEqual(lines[12], 'double:=25.5566')
+                self.assertEqual(lines[13], 'string:=This is a long string of information that is important.')
+                self.assertEqual(lines[14], 'int list:=1 2 3 4 5 100')
+                self.assertEqual(lines[15], 'double list:=0.2 0.502 0.8')
+                self.assertEqual(lines[16], 'string list:=words are split by space in list')
+                self.assertEqual(lines[17], 'int vector:=(100, 200, -300)')
+                self.assertEqual(lines[18], 'double vector:=(100.5,200.3,-300.99)')
+                self.assertEqual(lines[19], 'int matrix:=(1,0,0) (0,1,0) (0,0,1)')
+                self.assertEqual(lines[20], 'double matrix:=(1.2,0.3,0) (0,1.5,0) (0,-0.55,1.6)')
+
+        def test_write_custom_fields_with_custom_field_map(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_custom_fields.nrrd')
+
+            custom_field_map = {'int': 'int',
+                                'double': 'double',
+                                'string': 'string',
+                                'int list': 'int list',
+                                'double list': 'double list',
+                                'string list': 'string list',
+                                'int vector': 'int vector',
+                                'double vector': 'double vector',
+                                'int matrix': 'int matrix',
+                                'double matrix': 'double matrix'}
+
+            data, header = nrrd.read(ASCII_1D_CUSTOM_FIELDS_FILE_PATH, custom_field_map, index_order=self.index_order)
+            nrrd.write(output_filename, data, header, custom_field_map=custom_field_map, index_order=self.index_order)
+
+            with open(output_filename) as fh:
+                lines = fh.readlines()
+
+                # Strip newline from end of line
+                lines = [line.rstrip() for line in lines]
+
+                self.assertEqual(lines[5], 'type: uint8')
+                self.assertEqual(lines[6], 'dimension: 1')
+                self.assertEqual(lines[7], 'sizes: 27')
+                self.assertEqual(lines[8], 'kinds: domain')
+                self.assertEqual(lines[9], 'encoding: ASCII')
+                self.assertEqual(lines[10], 'spacings: 1.0458000000000001')
+                self.assertEqual(lines[11], 'int:=24')
+                self.assertEqual(lines[12], 'double:=25.5566')
+                self.assertEqual(lines[13], 'string:=This is a long string of information that is important.')
+                self.assertEqual(lines[14], 'int list:=1 2 3 4 5 100')
+                self.assertEqual(lines[15], 'double list:=0.20000000000000001 0.502 0.80000000000000004')
+                self.assertEqual(lines[16], 'string list:=words are split by space in list')
+                self.assertEqual(lines[17], 'int vector:=(100,200,-300)')
+                self.assertEqual(lines[18], 'double vector:=(100.5,200.30000000000001,-300.99000000000001)')
+                self.assertEqual(lines[19], 'int matrix:=(1,0,0) (0,1,0) (0,0,1)')
+                self.assertEqual(lines[20], 'double matrix:=(1.2,0.29999999999999999,0) (0,1.5,0) (0,-0.55000000000000004,'
+                                            '1.6000000000000001)')
+
+        def test_write_detached_raw_as_nrrd(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
+            output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nrrd')
+
+            nrrd.write(output_data_filename, self.data_input, {'encoding': 'raw'}, detached_header=True,
+                    relative_data_path=False, index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(header['encoding'], 'raw')
+            self.assertEqual(header['data file'], output_data_filename)
+
+        def test_write_detached_raw_odd_extension(self):
+            output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nrrd2')
+
+            nrrd.write(output_data_filename, self.data_input, {'encoding': 'raw'}, detached_header=True,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_data_filename, index_order=self.index_order)
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(header['encoding'], 'raw')
+            self.assertEqual('data file' in header, False)
+
+        def test_write_fake_encoding(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
+
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid encoding specification while writing NRRD file: fake'):
+                nrrd.write(output_filename, self.data_input, {'encoding': 'fake'}, index_order=self.index_order)
+
+        def test_write_detached_raw(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
+
+            # Data & header are still detached even though detached_header is False because the filename is .nhdr
+            # Test also checks detached data filename that it is relative (default value)
+            nrrd.write(output_filename, self.data_input, {'encoding': 'raw'}, detached_header=False,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(header['encoding'], 'raw')
+            self.assertEqual(header['data file'], 'testfile_detached_raw.raw')
+
+        def test_write_detached_gz(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
+            output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.raw.gz')
+
+            # Data & header are still detached even though detached_header is False because the filename is .nhdr
+            # Test also checks detached data filename that it is absolute
+            nrrd.write(output_filename, self.data_input, {'encoding': 'gz'}, detached_header=False,
+                    relative_data_path=False, index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(header['encoding'], 'gz')
+            self.assertEqual(header['data file'], output_data_filename)
+
+        def test_write_detached_bz2(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
+
+            # Data & header are still detached even though detached_header is False because the filename is .nhdr
+            # Test also checks detached data filename that it is relative (default value)
+            nrrd.write(output_filename, self.data_input, {'encoding': 'bz2'}, detached_header=False,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(header['encoding'], 'bz2')
+            self.assertEqual(header['data file'], 'testfile_detached_raw.raw.bz2')
+
+        def test_write_detached_ascii(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
+
+            # Data & header are still detached even though detached_header is False because the filename is .nhdr
+            # Test also checks detached data filename that it is relative (default value)
+            nrrd.write(output_filename, self.data_input, {'encoding': 'txt'}, detached_header=False,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(header['encoding'], 'txt')
+            self.assertEqual(header['data file'], 'testfile_detached_raw.txt')
+
+        def test_invalid_custom_field(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_invalid_custom_field.nrrd')
+            header = {'int': 12}
+            custom_field_map = {'int': 'fake'}
+
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid field type given: fake'):
+                nrrd.write(output_filename, np.zeros((3, 9)), header, custom_field_map=custom_field_map,
+                        index_order=self.index_order)
+
+        def test_remove_endianness(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_remove_endianness.nrrd')
+
+            x = np.arange(1, 28)
+            nrrd.write(output_filename, x, {'encoding': 'ascii', 'endian': 'little', 'space': 'right-anterior-superior',
+                                            'space dimension': 3}, index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(header['encoding'], 'ascii')
+
+            # Check for endian and space dimension, both of these should have been removed from the header
+            # Endian because it is an ASCII encoded file and space dimension because space is specified
+            self.assertFalse('endian' in header)
+            self.assertFalse('space dimension' in header)
+            np.testing.assert_equal(data, x)
+
+        def test_unsupported_encoding(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_unsupported_encoding.nrrd')
+            header = {'encoding': 'fake'}
+
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Unsupported encoding: "fake"'):
+                nrrd.write(output_filename, np.zeros((3, 9)), header, index_order=self.index_order)
+
+        def test_invalid_index_order(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_invalid_index_order.nrrd')
+
+            with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid index order'):
+                nrrd.write(output_filename, np.zeros((3, 9)), index_order=None)
+
+        def test_quoted_string_list_header(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_ascii_3d.nrrd')
+
+            x = np.arange(1, 28).reshape((3, 3, 3), order=self.index_order)
+            nrrd.write(output_filename, x, {
+                'encoding': 'ascii',
+                'units': ['mm', 'cm', 'in'],
+                'space units': ['mm', 'cm', 'in'],
+                'labels': ['X', 'Y', 'f(log(X, 10), Y)'],
+            }, index_order=self.index_order)
+
+            with open(output_filename) as fh:
+                lines = fh.readlines()
+
+                # Strip newline from end of line
+                lines = [line.rstrip() for line in lines]
+
+                # Note the order of the lines dont matter, we just want to verify theyre outputted correctly
+                self.assertTrue('units: "mm" "cm" "in"' in lines)
+                self.assertTrue('space units: "mm" "cm" "in"' in lines)
+                self.assertTrue('labels: "X" "Y" "f(log(X, 10), Y)"' in lines)
+
+        def test_write_detached_datafile_check(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
+
+            nrrd.write(output_filename, self.data_input, {'datafile': 'testfile_detachedWRONG.gz'}, detached_header=True,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(header['data file'], 'testfile_detached.raw.gz')
+
+        def test_write_detached_datafile_check2(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
+
+            nrrd.write(output_filename, self.data_input, {'data file': 'testfile_detachedWRONG.gz'}, detached_header=True,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(header['data file'], 'testfile_detached.raw.gz')
+
+        def test_write_detached_datafile_custom_name(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
+            # Specify a custom path to write the
+            output_header_filename = os.path.join(self.temp_write_dir, 'testfile_detachedDifferent.gz')
+
+            nrrd.write(output_filename, self.data_input, detached_header=output_header_filename,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertEqual(header['data file'], 'testfile_detachedDifferent.gz')
+
+        def test_write_check_remove_datafile(self):
+            output_filename = os.path.join(self.temp_write_dir, 'testfile.nrrd')
+
+            nrrd.write(output_filename, self.data_input, {'data file': 'testfile_detached.gz'}, detached_header=False,
+                    index_order=self.index_order)
+
+            # Read back the same file
+            # The 'data file' parameter should be missing since this is NOT a detached file
+            data, header = nrrd.read(output_filename, index_order=self.index_order)
+            self.assertFalse('data file' in header)
+
+        def test_write_memory(self):
+            default_output_filename = os.path.join(self.temp_write_dir, 'testfile_default_filename.nrrd')
+            nrrd.write(default_output_filename, self.data_input, {}, index_order=self.index_order)
+
+            memory_nrrd = io.BytesIO()
 
             nrrd.write(memory_nrrd, self.data_input, {}, index_order=self.index_order)
 
-        data, header = nrrd.read(default_output_filename, index_order=self.index_order)
+            memory_nrrd.seek(0)
 
-        with open(default_output_memory_filename, mode='rb') as memory_nrrd:
+            data, header = nrrd.read(default_output_filename, index_order=self.index_order)
             memory_header = nrrd.read_header(memory_nrrd)
-            memory_data = nrrd.read_data(header=memory_header, fh=memory_nrrd, filename=None,
-                                         index_order=self.index_order)
+            memory_data = nrrd.read_data(header=memory_header, fh=memory_nrrd, filename=None, index_order=self.index_order)
 
-        self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
-        self.assertEqual(self.expected_data, memory_data.tobytes(order=self.index_order))
-        self.assertEqual(header.pop('sizes').all(), memory_header.pop('sizes').all())
-        self.assertSequenceEqual(header, memory_header)
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(self.expected_data, memory_data.tobytes(order=self.index_order))
+            self.assertEqual(header.pop('sizes').all(), memory_header.pop('sizes').all())
+            self.assertSequenceEqual(header, memory_header)
+
+        def test_write_memory_file_handle(self):
+            default_output_filename = os.path.join(self.temp_write_dir, 'testfile_default_filename.nrrd')
+            nrrd.write(default_output_filename, self.data_input, {}, index_order=self.index_order)
+
+            default_output_memory_filename = os.path.join(self.temp_write_dir, 'testfile_default_memory_filename.nrrd')
+
+            with open(default_output_memory_filename, mode='wb') as memory_nrrd:
+
+                nrrd.write(memory_nrrd, self.data_input, {}, index_order=self.index_order)
+
+            data, header = nrrd.read(default_output_filename, index_order=self.index_order)
+
+            with open(default_output_memory_filename, mode='rb') as memory_nrrd:
+                memory_header = nrrd.read_header(memory_nrrd)
+                memory_data = nrrd.read_data(header=memory_header, fh=memory_nrrd, filename=None,
+                                            index_order=self.index_order)
+
+            self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
+            self.assertEqual(self.expected_data, memory_data.tobytes(order=self.index_order))
+            self.assertEqual(header.pop('sizes').all(), memory_header.pop('sizes').all())
+            self.assertSequenceEqual(header, memory_header)
 
 
-class TestWritingFunctionsFortran(TestWritingFunctions, unittest.TestCase):
+class TestWritingFunctionsFortran(Abstract.TestWritingFunctions):
     index_order = 'F'
 
 
-class TestWritingFunctionsC(TestWritingFunctions, unittest.TestCase):
+class TestWritingFunctionsC(Abstract.TestWritingFunctions):
     index_order = 'C'
 
 

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -1,9 +1,10 @@
 import io
 import tempfile
 import unittest
-from typing import ClassVar, Literal
+from typing import ClassVar
 
 import numpy as np
+from typing_extensions import Literal
 
 import nrrd
 from nrrd.tests.util import *

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -1,7 +1,7 @@
 import io
 import tempfile
-from typing import ClassVar, Literal
 import unittest
+from typing import ClassVar, Literal
 
 import numpy as np
 

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -26,7 +26,7 @@ class Abstract:
             if encoding is not None:
                 headers['encoding'] = encoding
             nrrd.write(output_filename, self.data_input, headers, compression_level=level,
-                    index_order=self.index_order)
+                       index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -159,15 +159,15 @@ class Abstract:
                 self.assertEqual(lines[17], 'int vector:=(100,200,-300)')
                 self.assertEqual(lines[18], 'double vector:=(100.5,200.30000000000001,-300.99000000000001)')
                 self.assertEqual(lines[19], 'int matrix:=(1,0,0) (0,1,0) (0,0,1)')
-                self.assertEqual(lines[20], 'double matrix:=(1.2,0.29999999999999999,0) (0,1.5,0) (0,-0.55000000000000004,'
-                                            '1.6000000000000001)')
+                self.assertEqual(lines[20], 'double matrix:=(1.2,0.29999999999999999,0) (0,1.5,0) (0,'
+                                            '-0.55000000000000004,1.6000000000000001)')
 
         def test_write_detached_raw_as_nrrd(self):
             output_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nhdr')
             output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nrrd')
 
             nrrd.write(output_data_filename, self.data_input, {'encoding': 'raw'}, detached_header=True,
-                    relative_data_path=False, index_order=self.index_order)
+                       relative_data_path=False, index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -179,7 +179,7 @@ class Abstract:
             output_data_filename = os.path.join(self.temp_write_dir, 'testfile_detached_raw.nrrd2')
 
             nrrd.write(output_data_filename, self.data_input, {'encoding': 'raw'}, detached_header=True,
-                    index_order=self.index_order)
+                       index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_data_filename, index_order=self.index_order)
@@ -199,7 +199,7 @@ class Abstract:
             # Data & header are still detached even though detached_header is False because the filename is .nhdr
             # Test also checks detached data filename that it is relative (default value)
             nrrd.write(output_filename, self.data_input, {'encoding': 'raw'}, detached_header=False,
-                    index_order=self.index_order)
+                       index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -214,7 +214,7 @@ class Abstract:
             # Data & header are still detached even though detached_header is False because the filename is .nhdr
             # Test also checks detached data filename that it is absolute
             nrrd.write(output_filename, self.data_input, {'encoding': 'gz'}, detached_header=False,
-                    relative_data_path=False, index_order=self.index_order)
+                       relative_data_path=False, index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -228,7 +228,7 @@ class Abstract:
             # Data & header are still detached even though detached_header is False because the filename is .nhdr
             # Test also checks detached data filename that it is relative (default value)
             nrrd.write(output_filename, self.data_input, {'encoding': 'bz2'}, detached_header=False,
-                    index_order=self.index_order)
+                       index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -242,7 +242,7 @@ class Abstract:
             # Data & header are still detached even though detached_header is False because the filename is .nhdr
             # Test also checks detached data filename that it is relative (default value)
             nrrd.write(output_filename, self.data_input, {'encoding': 'txt'}, detached_header=False,
-                    index_order=self.index_order)
+                       index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -257,7 +257,7 @@ class Abstract:
 
             with self.assertRaisesRegex(nrrd.NRRDError, 'Invalid field type given: fake'):
                 nrrd.write(output_filename, np.zeros((3, 9)), header, custom_field_map=custom_field_map,
-                        index_order=self.index_order)
+                           index_order=self.index_order)
 
         def test_remove_endianness(self):
             output_filename = os.path.join(self.temp_write_dir, 'testfile_remove_endianness.nrrd')
@@ -314,8 +314,9 @@ class Abstract:
         def test_write_detached_datafile_check(self):
             output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
 
-            nrrd.write(output_filename, self.data_input, {'datafile': 'testfile_detachedWRONG.gz'}, detached_header=True,
-                    index_order=self.index_order)
+            nrrd.write(output_filename, self.data_input, {'datafile': 'testfile_detachedWRONG.gz'},
+                       detached_header=True,
+                       index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -324,8 +325,9 @@ class Abstract:
         def test_write_detached_datafile_check2(self):
             output_filename = os.path.join(self.temp_write_dir, 'testfile_detached.nhdr')
 
-            nrrd.write(output_filename, self.data_input, {'data file': 'testfile_detachedWRONG.gz'}, detached_header=True,
-                    index_order=self.index_order)
+            nrrd.write(output_filename, self.data_input, {'data file': 'testfile_detachedWRONG.gz'},
+                       detached_header=True,
+                       index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -337,7 +339,7 @@ class Abstract:
             output_header_filename = os.path.join(self.temp_write_dir, 'testfile_detachedDifferent.gz')
 
             nrrd.write(output_filename, self.data_input, detached_header=output_header_filename,
-                    index_order=self.index_order)
+                       index_order=self.index_order)
 
             # Read back the same file
             data, header = nrrd.read(output_filename, index_order=self.index_order)
@@ -347,7 +349,7 @@ class Abstract:
             output_filename = os.path.join(self.temp_write_dir, 'testfile.nrrd')
 
             nrrd.write(output_filename, self.data_input, {'data file': 'testfile_detached.gz'}, detached_header=False,
-                    index_order=self.index_order)
+                       index_order=self.index_order)
 
             # Read back the same file
             # The 'data file' parameter should be missing since this is NOT a detached file
@@ -366,7 +368,8 @@ class Abstract:
 
             data, header = nrrd.read(default_output_filename, index_order=self.index_order)
             memory_header = nrrd.read_header(memory_nrrd)
-            memory_data = nrrd.read_data(header=memory_header, fh=memory_nrrd, filename=None, index_order=self.index_order)
+            memory_data = nrrd.read_data(header=memory_header, fh=memory_nrrd, filename=None,
+                                         index_order=self.index_order)
 
             self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
             self.assertEqual(self.expected_data, memory_data.tobytes(order=self.index_order))
@@ -380,7 +383,6 @@ class Abstract:
             default_output_memory_filename = os.path.join(self.temp_write_dir, 'testfile_default_memory_filename.nrrd')
 
             with open(default_output_memory_filename, mode='wb') as memory_nrrd:
-
                 nrrd.write(memory_nrrd, self.data_input, {}, index_order=self.index_order)
 
             data, header = nrrd.read(default_output_filename, index_order=self.index_order)
@@ -388,7 +390,7 @@ class Abstract:
             with open(default_output_memory_filename, mode='rb') as memory_nrrd:
                 memory_header = nrrd.read_header(memory_nrrd)
                 memory_data = nrrd.read_data(header=memory_header, fh=memory_nrrd, filename=None,
-                                            index_order=self.index_order)
+                                             index_order=self.index_order)
 
             self.assertEqual(self.expected_data, data.tobytes(order=self.index_order))
             self.assertEqual(self.expected_data, memory_data.tobytes(order=self.index_order))

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -1,5 +1,6 @@
 import io
 import tempfile
+from typing import ClassVar, Literal
 import unittest
 
 import numpy as np
@@ -10,6 +11,8 @@ from nrrd.tests.util import *
 
 class Abstract:
     class TestWritingFunctions(unittest.TestCase):
+        index_order: ClassVar[Literal['F', 'C']]
+
         def setUp(self):
             self.temp_write_dir = tempfile.mkdtemp('nrrdtest')
             self.data_input, _ = nrrd.read(RAW_NRRD_FILE_PATH, index_order=self.index_order)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 numpy>=1.11.1
+typing_extensions


### PR DESCRIPTION
* Make `TestReadingFunctions` & `TestWritingFunctions` subclass of `unittest.TestCase` for better type suggestions. However, since this test case is meant to be abstract, we nest the class in an `Abstract` class to prevent test discovery of this class.
* Add `index_order` typing for `TestReadingFunctions` and `TestWritingFunctions`
