### PR TITLE
Minor formatting fix to error message

### DIFF
--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -156,7 +156,7 @@ def _determine_datatype(fields):
     # Note: Endian is not required for ASCII encoding
     if np.dtype(np_typestring).itemsize > 1 and fields['encoding'] not in ['ASCII', 'ascii', 'text', 'txt']:
         if 'endian' not in fields:
-            raise NRRDError('Header is missing required field: "endian".')
+            raise NRRDError('Header is missing required field: endian')
         elif fields['endian'] == 'big':
             np_typestring = '>' + np_typestring
         elif fields['endian'] == 'little':

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -395,7 +395,7 @@ class Abstract:
                 # Since our data is short (itemsize = 2), we should receive an error
                 del header['endian']
 
-                with self.assertRaisesRegex(nrrd.NRRDError, 'Header is missing required field: "endian".'):
+                with self.assertRaisesRegex(nrrd.NRRDError, 'Header is missing required field: endian'):
                     nrrd.read_data(header, fh, RAW_NRRD_FILE_PATH)
 
         def test_big_endian(self):


### PR DESCRIPTION
Remove quotes from error message. Provides consistency with other error messages