### PR TITLE
Update docs requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 numpy>=1.11.1
 numpydoc
+nptyping
+typing_extensions


### PR DESCRIPTION
Include missing deps in docs/requirements.txt

Note that `readthedocs` does **not** install the requirements in the root of this library.