### PR TITLE
Do not load nrrd package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,11 @@ import os
 
 from setuptools import find_packages, setup
 
-from nrrd._version import __version__
-
 currentPath = os.path.abspath(os.path.dirname(__file__))
+
+# Get __version__ from _version.py
+with open(os.path.join(currentPath, 'nrrd/_version.py')) as fh:
+    exec(fh.read())
 
 # Get the long description from the README file
 with open(os.path.join(currentPath, 'README.rst')) as fh:

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import find_packages, setup
 currentPath = os.path.abspath(os.path.dirname(__file__))
 
 # Get __version__ from _version.py
+__version__ = None
 with open(os.path.join(currentPath, 'nrrd/_version.py')) as fh:
     exec(fh.read())
 


### PR DESCRIPTION
Prevent importing `nrrd` package in `setup.py` because this causes an error about `nptyping` package missing whilst running setup.py which is in the process of installing the packages.

The fix is to read the `_version.py` file specifically without importing the package.