### PR TITLE
Allow custom field map to override default field types

### DIFF
--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -87,7 +87,9 @@ _TYPEMAP_NRRD2NUMPY = {
 
 
 def _get_field_type(field: str, custom_field_map: Optional[NRRDFieldMap]) -> NRRDFieldType:
-    if field in ['dimension', 'lineskip', 'line skip', 'byteskip', 'byte skip', 'space dimension']:
+    if custom_field_map and field in custom_field_map:
+        return custom_field_map[field]
+    elif field in ['dimension', 'lineskip', 'line skip', 'byteskip', 'byte skip', 'space dimension']:
         return 'int'
     elif field in ['min', 'max', 'oldmin', 'old min', 'oldmax', 'old max']:
         return 'double'
@@ -111,9 +113,6 @@ def _get_field_type(field: str, custom_field_map: Optional[NRRDFieldMap]) -> NRR
     elif field in ['space directions']:
         return 'double matrix'
     else:
-        if custom_field_map and field in custom_field_map:
-            return custom_field_map[field]
-
         # Default the type to string if unknown type
         return 'string'
 


### PR DESCRIPTION
Thanks for writing this library! The nrrd spec says that the `space directions` field must be a list of some combination of vectors (for spatial axes) and `none` (for non-spatial axes like color). It looks to me like pynrrd insists that `space directions` is a matrix and so it does not support the ability to add `none` entries. I made a small change to enable this.

With this commit, it becomes possible to override the default type of a header field. By overriding the default type of `space directions` with `'string'`, users can provide a string value for this that is directly put into the file header. Users will have to know that the proper format of the `space directions` field is something like

    (0,0,0.8) (0,0.8,0) (2,0,0) none

to produce a valid .nrrd header, but at least this is now possible.

As a result, a command like this succeeds in producing a nrrd file that has a correctly specified header for a dataset that is xyz plus a color channel:
```python
import nrrd
nrrd.write(
    'examplenrrd_3spatialdimspluscolor.nrrd',
    np.random.randint(0, 2**16, size=(2, 100, 256, 256), dtype=np.uint16),
    header={'encoding': 'raw',
            'dimension': 4,
            'space dimension': 3,
            'space directions': '(0,0,0.8) (0,0.8,0) (2,0,0) none',
            'space units': ['microns', 'microns', 'microns']},
    custom_field_map={'space directions': 'string'},
    index_order='C')
```
And get a proper header:
```
NRRD0005
# This NRRD file was generated by pynrrd
# on 2024-07-26 12:37:49(GMT).
# Complete NRRD file format specification at:
# http://teem.sourceforge.net/nrrd/format.html
type: uint16
dimension: 4
space dimension: 3
sizes: 256 256 100 2
space directions: (0,0,0.8) (0,0.8,0) (2,0,0) none
endian: little
encoding: raw
space units: "microns" "microns" "microns"
```
I have confirmed that this is a proper header according to the nrrd spec using the `unu` tool from teem, (which the devs have said [here](https://github.com/JuliaIO/NRRD.jl/issues/17#issuecomment-498851155) is the recommended way to confirm header conformance):
```
$ unu minmax examplenrrd_3spatialdimspluscolor.nrrd 
min: 0
max: 65535
```

Note that if I remove the `none` from the header, I get the appropriate complaint from `unu`:
```
$ unu minmax examplenrrd_3spatialdimspluscolor.nrrd 
unu minmax: trouble with "examplenrrd_3spatialdimspluscolor.nrrd":
[unu minmax] unu minmax: trouble loading "examplenrrd_3spatialdimspluscolor.nrrd"
[unu minmax] [nrrd] nrrdLoad: trouble reading "examplenrrd_3spatialdimspluscolor.nrrd"
[unu minmax] [nrrd] nrrdRead: trouble
[unu minmax] [nrrd] _nrrdRead: trouble reading NRRD file
[unu minmax] [nrrd] _nrrdFormatNRRD_read: trouble parsing space directions info |(0,0,0.8) (0,0.8,0) (2,0,0)|
[unu minmax] [nrrd] _nrrdReadNrrdParse_space_directions: trouble getting space vector 4 of 4
[unu minmax] [nrrd] _nrrdSpaceVectorParse: hit end of string before seeing (
```


I would guess this commit wouldn't cause any issues in existing code anywhere in the world, since before this the custom field map would just be ignored for any standard metadata fields, and the behavior is only changed when providing custom field types for the standard fields.

Feel free to merge this PR if you agree this change is a move in the correct direction. Thanks!