### PR TITLE
Modernize

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: pip install pre-commit

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ docs/build/
 
 # coverage.py files
 .coverage
+
+# Virtual environments
+.venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,24 +2,29 @@ exclude: "docs"
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.17.0
     hooks:
       -  id: pyupgrade
          args: [--py37-plus]
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 5.0.4
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
     hooks:
       - id: flake8
         args: ["--config=setup.cfg"]
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.24.5
+    hooks:
+      - id: typos

--- a/nrrd/tests/test_writing.py
+++ b/nrrd/tests/test_writing.py
@@ -329,7 +329,7 @@ class Abstract:
                 # Strip newline from end of line
                 lines = [line.rstrip() for line in lines]
 
-                # Note the order of the lines dont matter, we just want to verify theyre outputted correctly
+                # Note the order of the lines dont matter, we just want to verify they are outputted correctly
                 self.assertTrue('units: "mm" "cm" "in"' in lines)
                 self.assertTrue('space units: "mm" "cm" "in"' in lines)
                 self.assertTrue('labels: "X" "Y" "f(log(X, 10), Y)"' in lines)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = ["build", "pre-commit", "pytest"]
 
 [project.urls]
 Homepage = "https://github.com/mhe/pynrrd"
+Documentation = "https://pynrrd.readthedocs.io/en/stable"
 Tracker = "https://github.com/mhe/pynrrd/issues"
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pynrrd"
 dynamic = ["version"]
 description = "Pure python module for reading and writing NRRD files."
-readme = {file = "README.txt", content-type = "text/x-rst"}
+readme = { file = "README.txt", content-type = "text/x-rst" }
 requires-python = ">=3.7"
 license = { text = "MIT License" }
 authors = [{ name = "Maarten Everts", email = "me@nn8.nl" }]
@@ -19,14 +19,10 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.11",
 ]
 
-dependencies = [
-    "numpy >=1.11.1",
-    "nptyping",
-    "typing_extensions"
-]
+dependencies = ["numpy >=1.11.1", "nptyping", "typing_extensions"]
 
 [project.optional-dependencies]
 dev = ["build", "pre-commit", "pytest"]
@@ -36,4 +32,7 @@ Homepage = "https://github.com/mhe/pynrrd"
 Tracker = "https://github.com/mhe/pynrrd/issues"
 
 [tool.setuptools.dynamic]
-version = {attr = "nrrd._version.__version__"}
+version = { attr = "nrrd._version.__version__" }
+
+[tool.setuptools.packages]
+find = { exclude = ["*.tests", "*.tests.*", "tests.*", "tests"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pynrrd"
+dynamic = ["version"]
+description = "Pure python module for reading and writing NRRD files."
+readme = {file = "README.txt", content-type = "text/x-rst"}
+requires-python = ">=3.7"
+license = { text = "MIT License" }
+authors = [{ name = "Maarten Everts", email = "me@nn8.nl" }]
+keywords = ["nrrd", "teem", "image", "processing", "file", "format"]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Scientific/Engineering",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11"
+]
+
+dependencies = [
+    "numpy >=1.11.1",
+    "nptyping",
+    "typing_extensions"
+]
+
+[project.optional-dependencies]
+dev = ["build", "pre-commit", "pytest"]
+
+[project.urls]
+Homepage = "https://github.com/mhe/pynrrd"
+Tracker = "https://github.com/mhe/pynrrd/issues"
+
+[tool.setuptools.dynamic]
+version = {attr = "nrrd._version.__version__"}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,3 @@
-[bdist_wheel]
-# This flag says that the code is written to work on both Python 2 and Python
-# 3. If at all possible, it is good practice to do this. If you cannot, you
-# will need to generate wheels for each Python version that you support.
-universal=1
-
 [flake8]
 max-line-length = 120
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
 
-
 if __name__ == "__main__":
     setup()

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,5 @@
-import os
+from setuptools import setup
 
-from setuptools import find_packages, setup
 
-currentPath = os.path.abspath(os.path.dirname(__file__))
-
-# Get __version__ from _version.py
-__version__ = None
-with open(os.path.join(currentPath, 'nrrd/_version.py')) as fh:
-    exec(fh.read())
-
-# Get the long description from the README file
-with open(os.path.join(currentPath, 'README.rst')) as fh:
-    longDescription = fh.read()
-
-longDescription = '\n' + longDescription
-
-setup(name='pynrrd',
-      python_requires='>=3.7',
-      version=__version__,
-      description='Pure python module for reading and writing NRRD files.',
-      long_description=longDescription,
-      long_description_content_type='text/x-rst',
-      author='Maarten Everts',
-      author_email='me@nn8.nl',
-      url='https://github.com/mhe/pynrrd',
-      license='MIT License',
-      install_requires=['numpy>=1.11.1', 'nptyping', 'typing_extensions'],
-      packages=find_packages(exclude=['*.tests', '*.tests.*', 'tests.*', 'tests']),
-      keywords='nrrd teem image processing file format',
-      classifiers=[
-          'License :: OSI Approved :: MIT License',
-          'Topic :: Scientific/Engineering',
-          'Programming Language :: Python',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8',
-          'Programming Language :: Python :: 3.9',
-          'Programming Language :: Python :: 3.10',
-          'Programming Language :: Python :: 3.11',
-      ],
-      project_urls={
-          'Tracker': 'https://github.com/mhe/pynrrd/issues',
-      }
-      )
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
move metadata from setup.py to pyproject.toml
- package version is dynamically extracted from `nrrd.__version__` 

upgrade pre-commit hooks
- replace flake8 hook by https://github.com/PyCQA/flake8, which is "standard" (running the old hook was asking me for a gitlab password)
- add typos hook (only found one typo, but doesn't cost much to run it)