### PR TITLE
Fix test failures for NumPy 2.0+

### DIFF
--- a/nrrd/tests/test_formatting.py
+++ b/nrrd/tests/test_formatting.py
@@ -42,8 +42,8 @@ class TestFieldFormatting(unittest.TestCase):
         self.assertEqual(nrrd.format_optional_vector(np.array([1.2, 2., 3.2])), '(1.2,2,3.2000000000000002)')
 
         self.assertEqual(nrrd.format_optional_vector(None), 'none')
-        self.assertEqual(nrrd.format_optional_vector(np.array([np.NaN, np.NaN, np.NaN])), 'none')
-        self.assertEqual(nrrd.format_optional_vector([np.NaN, np.NaN, np.NaN]), 'none')
+        self.assertEqual(nrrd.format_optional_vector(np.array([np.nan, np.nan, np.nan])), 'none')
+        self.assertEqual(nrrd.format_optional_vector([np.nan, np.nan, np.nan]), 'none')
 
     def test_format_matrix(self):
         self.assertEqual(nrrd.format_matrix(np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])), '(1,2,3) (4,5,6) (7,8,9)')
@@ -77,10 +77,10 @@ class TestFieldFormatting(unittest.TestCase):
                          '(7.7000000000000002,8.8000000000000007,9.9000000000000004)')
 
         self.assertEqual(nrrd.format_optional_matrix(np.array([
-            [np.NaN, np.NaN, np.NaN], [1, 2, 3], [4, 5, 6], [7, 8, 9]])),
+            [np.nan, np.nan, np.nan], [1, 2, 3], [4, 5, 6], [7, 8, 9]])),
             'none (1,2,3) (4,5,6) (7,8,9)')
         self.assertEqual(nrrd.format_optional_matrix(np.array([
-            [1, 2, 3], [np.NaN, np.NaN, np.NaN], [4, 5, 6], [7, 8, 9]])),
+            [1, 2, 3], [np.nan, np.nan, np.nan], [4, 5, 6], [7, 8, 9]])),
             '(1,2,3) none (4,5,6) (7,8,9)')
 
     def test_format_number_list(self):

--- a/nrrd/tests/test_parsing.py
+++ b/nrrd/tests/test_parsing.py
@@ -119,12 +119,12 @@ class TestFieldParsing(unittest.TestCase):
 
         self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
             'none (1.4726600000000003,-0,0) (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
-            [[np.NaN, np.NaN, np.NaN], [1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0],
+            [[np.nan, np.nan, np.nan], [1.4726600000000003, 0, 0], [0, 1.4726600000000003, 0],
              [0, 0, 4.7619115092114601]])
 
         self.assert_equal_with_datatype(nrrd.parse_optional_matrix(
             '(1.4726600000000003,-0,0) none (-0,1.4726600000000003,-0) (0,-0,4.7619115092114601)'),
-            [[1.4726600000000003, 0, 0], [np.NaN, np.NaN, np.NaN], [0, 1.4726600000000003, 0],
+            [[1.4726600000000003, 0, 0], [np.nan, np.nan, np.nan], [0, 1.4726600000000003, 0],
              [0, 0, 4.7619115092114601]])
 
         with self.assertRaisesRegex(nrrd.NRRDError, 'Matrix should have same number of elements in each row'):

--- a/nrrd/tests/test_reading.py
+++ b/nrrd/tests/test_reading.py
@@ -235,7 +235,7 @@ class Abstract:
                                'space directions': np.array([[1.5, 0., 0.],
                                                              [0., 1.5, 0.],
                                                              [0., 0., 1.],
-                                                             [np.NaN, np.NaN, np.NaN]]),
+                                                             [np.nan, np.nan, np.nan]]),
                                'endian': 'little',
                                'encoding': 'raw',
                                'measurement frame': np.array([[1.0001, 0., 0.],


### PR DESCRIPTION
Migrate from `np.NaN` to `np.nan`. The former was removed in NumPy >2