### PR TITLE
Fix tests failing in CI/CD

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.14
+          python-version: 3.13
 
       - name: Install Python dependencies
         run: pip install pre-commit

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   run-hooks:
     name: Run pre-commit hooks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out Git repository
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: 3.14
 
       - name: Install Python dependencies
         run: pip install pre-commit

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.9', '3.14']
+        python-version: ['3.7', '3.9', '3.13']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.9', '3.13']
+        python-version: ['3.7', '3.9', '3.12']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,10 @@ on: [push, pull_request]
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.9']
+        python-version: ['3.7', '3.9', '3.14']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = ["numpy >= 1.21", "typing_extensions"]


### PR DESCRIPTION
Pin Ubuntu version to 22.04 for all workflows. This fixes the issue with tests failing on Python 3.7 due to Python 3.7 not being available on the latest Ubuntu OS (see here: https://github.com/actions/setup-python/issues/962). Pinning the OS version on **all** workflows should limit unforeseen errors due to an a new latest OS.

Update Python version used in lint/publish workflows to 13. This is the latest available for Ubuntu 22.04.

Add Python 3.12 version to tests for CI. **Note:** Tests fail when testing with Python 3.13. This will be fixed in an upcoming PR.

Add Python 3.12/3.13 to list of supported versions.
