### PR TITLE
Fix Python 13 deprecation warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.7', '3.9', '3.12']
+        python-version: ['3.7', '3.9', '3.13']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/nrrd/reader.py
+++ b/nrrd/reader.py
@@ -279,7 +279,7 @@ def read_header(file: Union[str, Iterable[AnyStr]], custom_field_map: Optional[N
             break
 
         # Read the field and value from the line, split using regex to search for := or : delimiter
-        field, value = re.split(r':=?', line, 1)
+        field, value = re.split(r':=?', line, maxsplit=1)
 
         # Remove whitespace before and after the field and value
         field, value = field.strip(), value.strip()


### PR DESCRIPTION
Fix warning regarding `maxsplit` argument in `re.split` being deprecated as a positional argument. In future Python versions, it will become an error and must be keyword-only.

Update Python test matrix to use 3.13.