### PR TITLE
Fix ReadTheDocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,9 @@ build:
   tools:
     python: "3.9"
 
+sphinx:
+  configuration: docs/source/conf.py
+
 python:
    install:
    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
ReadTheDocs failed to build due to missing configuration key as mentioned here: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

Additionally, update the OS & Python version.